### PR TITLE
fix: show hidden system apps (e.g. Android Auto) in app lists

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/ui/appmanagement/AppManagementViewModel.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/appmanagement/AppManagementViewModel.kt
@@ -88,7 +88,7 @@ class AppManagementViewModel(
             try {
                 val apps = withContext(Dispatchers.IO) {
                     val pm = application.applicationContext.packageManager
-                    pm.getInstalledApplications(PackageManager.GET_META_DATA)
+                    pm.getInstalledApplications(PackageManager.GET_META_DATA or PackageManager.MATCH_UNINSTALLED_PACKAGES)
                         .filter { it.packageName != application.applicationContext.packageName }
                         .map { appInfo ->
                             AppManagementData(

--- a/app/src/main/java/app/pwhs/blockads/ui/firewall/FirewallViewModel.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/firewall/FirewallViewModel.kt
@@ -50,7 +50,7 @@ class FirewallViewModel(
             _isLoading.value = true
             val apps = withContext(Dispatchers.IO) {
                 val pm = application.applicationContext.packageManager
-                pm.getInstalledApplications(PackageManager.GET_META_DATA)
+                pm.getInstalledApplications(PackageManager.GET_META_DATA or PackageManager.MATCH_UNINSTALLED_PACKAGES)
                     .filter { it.packageName != application.applicationContext.packageName }
                     .map { appInfo ->
                         val isSystem = (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0

--- a/app/src/main/java/app/pwhs/blockads/ui/whitelist/AppWhitelistViewModel.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/whitelist/AppWhitelistViewModel.kt
@@ -43,7 +43,7 @@ class AppWhitelistViewModel(
             _isLoading.value = true
             val apps = withContext(Dispatchers.IO) {
                 val pm = application.applicationContext.packageManager
-                pm.getInstalledApplications(PackageManager.GET_META_DATA)
+                pm.getInstalledApplications(PackageManager.GET_META_DATA or PackageManager.MATCH_UNINSTALLED_PACKAGES)
                     .filter { it.packageName != application.applicationContext.packageName }
                     .map { appInfo ->
                         val isSystem = (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0


### PR DESCRIPTION
## Problem

Some system apps like **Android Auto** (`com.google.android.projection.gearhead`) are intentionally hidden by Android and do not appear in the app lists (App Management, Whitelist, Firewall). This makes it impossible for users to whitelist them from the VPN tunnel, which is required for Android Auto to function correctly.

Android hides these apps by marking them with internal flags that cause `PackageManager.getInstalledApplications(GET_META_DATA)` to omit them from results.

## Fix

Add the `MATCH_UNINSTALLED_PACKAGES` flag to `getInstalledApplications()` calls in the three ViewModels:
- `AppManagementViewModel`
- `AppWhitelistViewModel`
- `FirewallViewModel`

This flag instructs PackageManager to return all packages including hidden/stub system apps, without requiring any additional permissions.

## Impact

Users can now find and whitelist Android Auto (and other hidden system apps) so that the VPN bypass works correctly for those apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Uninstalled applications now appear in app management, firewall, and whitelist features, providing comprehensive visibility and control of all applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->