### PR TITLE
feat: add Shizuku ADB root support for Root Proxy mode

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,6 +102,7 @@ android {
     buildFeatures {
         compose = true
         buildConfig = true
+        aidl = true
     }
 
     dependenciesInfo {
@@ -197,6 +198,10 @@ dependencies {
     // libsu — root shell access for iptables mode
     implementation(libs.core)
     implementation(libs.service)
+
+    // Shizuku — ADB root shell access (alternative to Magisk/KernelSU)
+    implementation(libs.shizuku.api)
+    implementation(libs.shizuku.provider)
 
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.navigation3.runtime)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -29,6 +29,10 @@
 # Keep VPN service
 -keep class app.pwhs.blockads.service.** { *; }
 
+# Shizuku
+-keep class rikka.shizuku.** { *; }
+-dontwarn rikka.shizuku.**
+
 # Go tunnel (gomobile)
 -keep class tunnel.** { *; }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -132,6 +132,15 @@
             android:name="io.sentry.auto-init"
             android:value="false" />
 
+        <!-- Shizuku — ADB root shell access -->
+        <provider
+            android:name="rikka.shizuku.ShizukuProvider"
+            android:authorities="${applicationId}.shizuku"
+            android:multiprocess="false"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/aidl/app/pwhs/blockads/service/IShizukuShellService.aidl
+++ b/app/src/main/aidl/app/pwhs/blockads/service/IShizukuShellService.aidl
@@ -1,0 +1,7 @@
+package app.pwhs.blockads.service;
+
+interface IShizukuShellService {
+    void destroy() = 16777114;
+    void exit() = 16777113;
+    String execCommand(String command) = 1;
+}

--- a/app/src/main/java/app/pwhs/blockads/service/IptablesManager.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/IptablesManager.kt
@@ -16,6 +16,10 @@ import timber.log.Timber
  * - nat table:    REDIRECT port 53 → 15353 (DNS interception)
  * - filter table: DROP port 853 (block DoT to force plain DNS)
  * - settings:     Disable Android Private DNS (forces port 53 fallback)
+ *
+ * Supports two shell backends:
+ * - LIBSU: Traditional root via Magisk/KernelSU
+ * - SHIZUKU: ADB root via Shizuku (for custom ROMs with ADB root debugging)
  */
 object IptablesManager {
 
@@ -23,14 +27,61 @@ object IptablesManager {
     private const val CHAIN_FILTER = "BLOCKADS_DOT"
     private const val LOCAL_DNS_PORT = 15353
 
+    enum class ShellBackend { LIBSU, SHIZUKU }
+
+    /** Which backend is currently active — set by [isRootAvailable]. */
+    var activeBackend: ShellBackend = ShellBackend.LIBSU
+        private set
+
     /**
-     * Actively request root access. This will trigger the Magisk/KernelSU
-     * permission prompt if it hasn't been granted yet.
+     * Actively request root access. Tries libsu (Magisk/KernelSU) first,
+     * then falls back to Shizuku if available.
+     *
+     * Sets [activeBackend] to whichever method succeeded.
      */
     fun isRootAvailable(): Boolean {
-        // Explicitly trigger 'su' so Magisk/KernelSU shows the permission prompt
-        val result = Shell.cmd("su -c id").exec()
-        return result.isSuccess && result.out.any { it.contains("uid=0") }
+        // Try libsu first (Magisk/KernelSU)
+        val libsuResult = Shell.cmd("su -c id").exec()
+        if (libsuResult.isSuccess && libsuResult.out.any { it.contains("uid=0") }) {
+            activeBackend = ShellBackend.LIBSU
+            Timber.d("Root available via libsu (Magisk/KernelSU)")
+            return true
+        }
+
+        // Fallback: try Shizuku
+        if (ShizukuManager.isRootAvailable()) {
+            activeBackend = ShellBackend.SHIZUKU
+            Timber.d("Root available via Shizuku (ADB root)")
+            return true
+        }
+
+        return false
+    }
+
+    // ── Shell abstraction ──────────────────────────────────────────
+    private data class CmdResult(val isSuccess: Boolean, val out: List<String>, val err: List<String>)
+
+    private fun exec(command: String): CmdResult {
+        return when (activeBackend) {
+            ShellBackend.LIBSU -> {
+                val r = Shell.cmd(command).exec()
+                CmdResult(r.isSuccess, r.out, r.err)
+            }
+            ShellBackend.SHIZUKU -> {
+                val r = ShizukuManager.exec(command)
+                CmdResult(r.isSuccess, r.out, r.err)
+            }
+        }
+    }
+
+    private fun execBatch(commands: List<String>) {
+        when (activeBackend) {
+            ShellBackend.LIBSU -> Shell.cmd(*commands.toTypedArray()).exec()
+            ShellBackend.SHIZUKU -> {
+                // Shizuku doesn't support batch — join with ';'
+                ShizukuManager.exec(commands.joinToString("; "))
+            }
+        }
     }
 
     /**
@@ -42,7 +93,7 @@ object IptablesManager {
      */
     fun setupRules(context: Context, blockDoT: Boolean = true): Boolean {
         val uid = context.applicationInfo.uid
-        Timber.d("Setting up iptables rules for UID=$uid, blockDoT=$blockDoT")
+        Timber.d("Setting up iptables rules for UID=$uid, blockDoT=$blockDoT, backend=$activeBackend")
 
         // Always teardown first (idempotent)
         teardownRules()
@@ -52,7 +103,7 @@ object IptablesManager {
         // This is CRITICAL — without this, Android 9+ uses DoT (853)
         // and our port 53 redirect never sees traffic.
         // ══════════════════════════════════════════════════════════════
-        Shell.cmd("settings put global private_dns_mode off").exec()
+        exec("settings put global private_dns_mode off")
         Timber.d("Disabled Android Private DNS (forced plain DNS mode)")
 
         // ══════════════════════════════════════════════════════════════
@@ -84,7 +135,7 @@ object IptablesManager {
 
         var ipv4Success = true
         for (cmd in ipv4Commands) {
-            val result = Shell.cmd(cmd).exec()
+            val result = exec(cmd)
             if (!result.isSuccess) {
                 Timber.e("IPv4 iptables cmd FAILED: [$cmd] err=${result.err} out=${result.out}")
                 ipv4Success = false
@@ -117,7 +168,7 @@ object IptablesManager {
         }
 
         for (cmd in ipv6Commands) {
-            val result = Shell.cmd(cmd).exec()
+            val result = exec(cmd)
             if (!result.isSuccess) {
                 Timber.w("IPv6 ip6tables cmd FAILED (ignoring): [$cmd] err=${result.err}")
             }
@@ -160,7 +211,7 @@ object IptablesManager {
             "settings put global private_dns_mode opportunistic",
         )
 
-        Shell.cmd(*commands.toTypedArray()).exec()
+        execBatch(commands)
         Timber.d("iptables teardown done, Private DNS restored")
         return true
     }
@@ -169,9 +220,7 @@ object IptablesManager {
      * Check if our iptables rules are currently active.
      */
     fun isActive(): Boolean {
-        val result = Shell.cmd(
-            "iptables -t nat -L OUTPUT -n 2>/dev/null | grep $CHAIN"
-        ).exec()
+        val result = exec("iptables -t nat -L OUTPUT -n 2>/dev/null | grep $CHAIN")
         return result.out.any { it.contains(CHAIN) }
     }
 }

--- a/app/src/main/java/app/pwhs/blockads/service/RootProxyService.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/RootProxyService.kt
@@ -201,7 +201,11 @@ class RootProxyService : Service() {
                     firewallManager = null
                 }
 
-                // 3. Retry loop for Standalone mode and IPTables setup
+                // 3. Detect root backend (libsu vs Shizuku) before applying iptables.
+                // After a reboot, activeBackend resets to LIBSU; this re-detects the correct one.
+                IptablesManager.isRootAvailable()
+
+                // 4. Retry loop for Standalone mode and IPTables setup
                 // This is crucial on boot where Magisk `su` might take a few seconds to become available
                 var proxyStarted = false
                 while (!proxyStarted && retryManager.shouldRetry()) {
@@ -253,6 +257,11 @@ class RootProxyService : Service() {
 
         // Teardown iptables rules (critical — prevents internet loss)
         IptablesManager.teardownRules()
+
+        // Release Shizuku shell service if it was used
+        if (IptablesManager.activeBackend == IptablesManager.ShellBackend.SHIZUKU) {
+            ShizukuManager.unbindService()
+        }
 
         // Stop Go engine
         goTunnelAdapter.stop()

--- a/app/src/main/java/app/pwhs/blockads/service/ShizukuManager.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/ShizukuManager.kt
@@ -1,0 +1,147 @@
+package app.pwhs.blockads.service
+
+import android.content.ComponentName
+import android.content.ServiceConnection
+import android.content.pm.PackageManager
+import android.os.IBinder
+import app.pwhs.blockads.BuildConfig
+import rikka.shizuku.Shizuku
+import timber.log.Timber
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+/**
+ * Manages Shizuku integration for executing privileged shell commands
+ * as an alternative to Magisk/KernelSU root.
+ *
+ * Shizuku only provides root-level access when the device has
+ * "ADB root debugging" enabled (common on custom ROMs where adbd
+ * runs as uid 0).
+ *
+ * Uses [ShizukuShellService] (AIDL user service) to run commands
+ * in Shizuku's privileged process.
+ */
+object ShizukuManager {
+
+    private const val REQUEST_PERMISSION_CODE = 10001
+    private const val BIND_TIMEOUT_SEC = 5L
+
+    @Volatile
+    private var shellService: IShizukuShellService? = null
+
+    private var serviceConnection: ServiceConnection? = null
+
+    /** True when Shizuku service is running and reachable. */
+    fun isAvailable(): Boolean {
+        return try {
+            Shizuku.pingBinder()
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /** True when this app already has Shizuku permission. */
+    fun isPermissionGranted(): Boolean {
+        return try {
+            isAvailable() && Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /** Shows the Shizuku permission dialog. */
+    fun requestPermission() {
+        if (isAvailable()) {
+            Shizuku.requestPermission(REQUEST_PERMISSION_CODE)
+        }
+    }
+
+    /**
+     * Check if Shizuku can provide root-level access.
+     * Returns true only when Shizuku is running, permission is granted,
+     * AND the server runs as uid 0 (ADB root debugging enabled).
+     */
+    fun isRootAvailable(): Boolean {
+        if (!isPermissionGranted()) return false
+        val result = exec("id")
+        return result.isSuccess && result.out.any { it.contains("uid=0") }
+    }
+
+    /**
+     * Bind the Shizuku user service synchronously (blocks up to [BIND_TIMEOUT_SEC] seconds).
+     * Returns true if the service is ready.
+     */
+    private fun ensureServiceBound(): Boolean {
+        if (shellService != null) return true
+
+        val future = CompletableFuture<IShizukuShellService>()
+        val conn = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName, service: IBinder) {
+                val svc = IShizukuShellService.Stub.asInterface(service)
+                shellService = svc
+                future.complete(svc)
+            }
+
+            override fun onServiceDisconnected(name: ComponentName) {
+                shellService = null
+            }
+        }
+
+        val args = Shizuku.UserServiceArgs(
+            ComponentName(BuildConfig.APPLICATION_ID, ShizukuShellService::class.java.name)
+        ).daemon(false).processNameSuffix("shell")
+
+        return try {
+            Shizuku.bindUserService(args, conn)
+            serviceConnection = conn
+            future.get(BIND_TIMEOUT_SEC, TimeUnit.SECONDS)
+            true
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to bind Shizuku shell service")
+            false
+        }
+    }
+
+    /**
+     * Execute a shell command through Shizuku's privileged process.
+     */
+    fun exec(command: String): ShellResult {
+        if (!ensureServiceBound()) {
+            return ShellResult(false, emptyList(), listOf("Shizuku service bind failed"))
+        }
+
+        return try {
+            val raw = shellService!!.execCommand(command)
+            val lines = raw.lines()
+            val exitCode = lines.firstOrNull()?.toIntOrNull() ?: -1
+            val output = lines.drop(1).filter { it.isNotEmpty() }
+            ShellResult(exitCode == 0, output, emptyList())
+        } catch (e: Exception) {
+            Timber.e(e, "Shizuku exec failed: %s", command)
+            shellService = null // Force rebind on next call
+            ShellResult(false, emptyList(), listOf(e.message ?: "Unknown error"))
+        }
+    }
+
+    /** Unbind the shell service. Called when root proxy is stopped. */
+    fun unbindService() {
+        serviceConnection?.let {
+            try {
+                val args = Shizuku.UserServiceArgs(
+                    ComponentName(BuildConfig.APPLICATION_ID, ShizukuShellService::class.java.name)
+                )
+                Shizuku.unbindUserService(args, it, true)
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to unbind Shizuku service")
+            }
+        }
+        serviceConnection = null
+        shellService = null
+    }
+
+    data class ShellResult(
+        val isSuccess: Boolean,
+        val out: List<String>,
+        val err: List<String>,
+    )
+}

--- a/app/src/main/java/app/pwhs/blockads/service/ShizukuShellService.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/ShizukuShellService.kt
@@ -1,0 +1,33 @@
+package app.pwhs.blockads.service
+
+/**
+ * Shizuku user service that runs shell commands with elevated privileges.
+ *
+ * This class is instantiated by Shizuku in a separate process (not the app's
+ * main process), so it must not reference app singletons like Timber, Koin, etc.
+ * It must have a no-arg constructor.
+ *
+ * The return format for [execCommand] is: "EXIT_CODE\nSTDOUT_CONTENT"
+ */
+class ShizukuShellService : IShizukuShellService.Stub() {
+
+    override fun destroy() {
+        // Called when Shizuku unbinds. No cleanup needed.
+    }
+
+    override fun exit() {
+        destroy()
+        System.exit(0)
+    }
+
+    override fun execCommand(command: String): String {
+        return try {
+            val process = Runtime.getRuntime().exec(arrayOf("sh", "-c", command))
+            val stdout = process.inputStream.bufferedReader().readText()
+            val exitCode = process.waitFor()
+            "$exitCode\n$stdout"
+        } catch (e: Exception) {
+            "-1\n${e.message}"
+        }
+    }
+}

--- a/app/src/main/java/app/pwhs/blockads/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/settings/SettingsViewModel.kt
@@ -31,6 +31,7 @@ import app.pwhs.blockads.worker.DailySummaryScheduler
 import app.pwhs.blockads.worker.FilterUpdateScheduler
 import app.pwhs.blockads.service.IptablesManager
 import app.pwhs.blockads.service.RootProxyService
+import app.pwhs.blockads.service.ShizukuManager
 import app.pwhs.blockads.utils.CrashReportingManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -162,7 +163,17 @@ class SettingsViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             if (enabled) {
                 if (IptablesManager.isRootAvailable()) {
+                    // Root available (via libsu or Shizuku)
                     applyRoutingMode(AppPreferences.ROUTING_MODE_ROOT)
+                } else if (ShizukuManager.isAvailable()) {
+                    if (!ShizukuManager.isPermissionGranted()) {
+                        // Shizuku running but permission not yet granted
+                        ShizukuManager.requestPermission()
+                        _events.toast(R.string.shizuku_permission_required)
+                    } else {
+                        // Permission granted but Shizuku server is not root
+                        _events.toast(R.string.shizuku_not_root)
+                    }
                 } else {
                     _events.toast(R.string.root_not_available)
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -661,8 +661,10 @@
     <string name="settings_network_switch_delay_desc">Pause VPN reconnect after network changes (useful for Wi-Fi Calling)</string>
     <string name="settings_network_switch_delay_value">Delay: %1$d seconds</string>
     <string name="settings_root_proxy">Root Proxy Mode</string>
-    <string name="settings_root_proxy_desc">Redirect DNS via iptables instead of VPN (requires Root)</string>
-    <string name="root_not_available">Root access not available. Please grant permission in your root manager (e.g., Magisk/KernelSU).</string>
+    <string name="settings_root_proxy_desc">Redirect DNS via iptables instead of VPN (requires Root or Shizuku)</string>
+    <string name="root_not_available">Root access not available. Please grant permission in your root manager (Magisk/KernelSU) or start Shizuku with ADB root.</string>
+    <string name="shizuku_permission_required">Shizuku permission required. Please grant and try again.</string>
+    <string name="shizuku_not_root">Shizuku is not running as root. Enable \"ADB root debugging\" in your custom ROM developer settings.</string>
     <string name="root_proxy_notification_text">Root Proxy mode active — DNS traffic redirected via iptables</string>
     <string name="reddit_link" translatable="false">https://www.reddit.com/r/BlockAds/</string>
     <string name="telegram_link" translatable="false">https://t.me/blockads_android</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ lifecycleRuntimeCompose = "2.10.0"
 nav3Core = "1.0.1"
 sentry = "6.3.0"
 sentry-android = "8.36.0"
+shizuku = "13.1.5"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -66,6 +67,8 @@ androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lif
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3Core" }
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "nav3Core" }
 sentry-android = { module = "io.sentry:sentry-android", version.ref = "sentry" }
+shizuku-api = { module = "dev.rikka.shizuku:api", version.ref = "shizuku" }
+shizuku-provider = { module = "dev.rikka.shizuku:provider", version.ref = "shizuku" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Allows devices without Magisk/KernelSU to use Root Proxy mode via Shizuku when ADB root debugging is enabled on custom ROMs. Falls back transparently: tries libsu first, then Shizuku.

Closes pass-with-high-score/discussions#139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shizuku support as an alternative to traditional root access for the Root Proxy Mode feature.
  * Users can now enable elevated operations using ADB root (via Shizuku) instead of requiring traditional root access.
  * Added permission request flow and user prompts for Shizuku integration with helpful error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->