### PR TITLE
Update Spanish strings for network switch settings

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -441,10 +441,10 @@
     <string name="vpn_conflict_title">Conexión Bloqueada</string>
     <string name="vpn_conflict_desc">Android solo permite una conexión VPN a la vez. Otra VPN está activa actualmente en tu dispositivo.\n\nPor favor, desconecta la otra VPN primero o desactiva la \&quot;VPN siempre activa\&quot; en los Ajustes antes de conectar BlockAds.</string>
     <string name="open_settings">Abrir Ajustes</string>
-    <string name="vpn_network_switch_waiting">Menunggu jaringan stabil… %1$ds</string>
-    <string name="settings_network_switch_delay">Penundaan Peralihan Jaringan</string>
-    <string name="settings_network_switch_delay_desc">Jeda penyambungan ulang VPN setelah perubahan jaringan (berguna untuk Panggilan Wi-Fi)</string>
-    <string name="settings_network_switch_delay_value">Penundaan: %1$d detik</string>
+    <string name="vpn_network_switch_waiting">Esperando red estable… %1$ds</string>
+    <string name="settings_network_switch_delay">Retraso en el cambio de red</string>
+    <string name="settings_network_switch_delay_desc">Retrasa la reconexión de la VPN después de un cambio de red (útil para Llamadas Wi-Fi)</string>
+    <string name="settings_network_switch_delay_value">Retraso: %1$d segundos</string>
     <string name="settings_root_proxy">Modo Proxy Root</string>
     <string name="settings_root_proxy_desc">Redirigir DNS vía iptables en lugar de VPN (requiere Root)</string>
     <string name="root_not_available">Acceso Root no disponible. Por favor, concede el permiso en tu administrador root (ej. Magisk/KernelSU).</string>


### PR DESCRIPTION
For some reason, some fields in the Spanish settings menu were instead written in Indonesian. This PR replaces the misplaced Indonesian text with the actual Spanish strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Spanish translations for VPN network switching features, including network stability wait notifications and delay configuration labels, descriptions, and value formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pass-with-high-score/blockads-android/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->