### PR TITLE
fix: Root Proxy mode not auto-starting after reboot (#179)

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/service/IptablesManager.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/IptablesManager.kt
@@ -24,6 +24,33 @@ object IptablesManager {
     private const val LOCAL_DNS_PORT = 15353
 
     /**
+     * Ensure the cached libsu main shell actually has root.
+     *
+     * libsu creates the main shell once and caches it for the process
+     * lifetime. If the first shell was created while the su daemon wasn't
+     * ready yet (typical right after boot), a non-root `sh` gets cached and
+     * every subsequent command silently runs without root — retries can
+     * never succeed. Closing the poisoned shell forces libsu to build a
+     * fresh one that attempts `su` again.
+     */
+    fun ensureRootShell(): Boolean {
+        val cached = Shell.getCachedShell()
+        if (cached != null && cached.isRoot) return true
+
+        if (cached != null) {
+            try {
+                cached.close()
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to close non-root shell")
+            }
+        }
+
+        val fresh = Shell.getShell()
+        Timber.d("Recreated libsu main shell, isRoot=${fresh.isRoot}")
+        return fresh.isRoot
+    }
+
+    /**
      * Actively request root access. This will trigger the Magisk/KernelSU
      * permission prompt if it hasn't been granted yet.
      */

--- a/app/src/main/java/app/pwhs/blockads/service/RootProxyService.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/RootProxyService.kt
@@ -101,7 +101,7 @@ class RootProxyService : Service() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var watchdogJob: Job? = null
     private var notificationUpdateJob: Job? = null
-    private val retryManager = VpnRetryManager(maxRetries = 10, maxDelayMs = 60000L)
+    private var retryManager = VpnRetryManager(maxRetries = 10, maxDelayMs = 60000L)
 
     @Volatile
     private var todayBlockedCount: Int = 0
@@ -167,6 +167,13 @@ class RootProxyService : Service() {
         createNotificationChannel()
         startForeground(NOTIFICATION_ID, buildNotification())
 
+        // On boot the su daemon (Magisk/KernelSU) can take well over the
+        // normal retry window to come up — allow a much longer budget.
+        retryManager = VpnRetryManager(
+            maxRetries = if (startedFromBoot) 30 else 10,
+            maxDelayMs = 60000L
+        )
+
         serviceScope.launch {
             try {
                 // 1. Load filters (same as VPN mode)
@@ -205,12 +212,21 @@ class RootProxyService : Service() {
                 // This is crucial on boot where Magisk `su` might take a few seconds to become available
                 var proxyStarted = false
                 while (!proxyStarted && retryManager.shouldRetry()) {
-                    val engineStarted = goTunnelAdapter.startStandalone(port = 15353)
-                    if (engineStarted) {
-                        if (IptablesManager.setupRules(this@RootProxyService)) {
-                            proxyStarted = true
-                        } else {
-                            goTunnelAdapter.stop() // stop engine if iptables fails
+                    // Recreate the libsu shell if a non-root one got cached
+                    // (happens when the first shell command ran before the
+                    // su daemon was ready — see #179). Without this, every
+                    // retry reuses the poisoned non-root shell and iptables
+                    // can never succeed.
+                    if (!IptablesManager.ensureRootShell()) {
+                        Timber.w("Root shell not available yet")
+                    } else {
+                        val engineStarted = goTunnelAdapter.startStandalone(port = 15353)
+                        if (engineStarted) {
+                            if (IptablesManager.setupRules(this@RootProxyService)) {
+                                proxyStarted = true
+                            } else {
+                                goTunnelAdapter.stop() // stop engine if iptables fails
+                            }
                         }
                     }
 
@@ -223,6 +239,7 @@ class RootProxyService : Service() {
                 if (!proxyStarted) {
                     Timber.e("Failed to start Root Proxy after ${retryManager.getMaxRetries()} attempts")
                     stopProxy()
+                    showStartFailedNotification()
                     return@launch
                 }
 
@@ -496,6 +513,57 @@ class RootProxyService : Service() {
         notificationManager.notify(NOTIFICATION_ID, notification)
     }
     
+    private fun showStartFailedNotification() {
+        createNotificationChannel()
+
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            this, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val retryIntent = Intent(this, RootProxyService::class.java).apply {
+            action = ACTION_START
+        }
+        val retryPendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            PendingIntent.getForegroundService(
+                this, 4, retryIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        } else {
+            PendingIntent.getService(
+                this, 4, retryIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        }
+
+        val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(this, CHANNEL_ID)
+        } else {
+            @Suppress("DEPRECATION")
+            Notification.Builder(this)
+        }
+
+        val notification = builder
+            .setContentTitle(getString(R.string.root_proxy_start_failed_title))
+            .setContentText(getString(R.string.root_proxy_start_failed_text))
+            .setStyle(Notification.BigTextStyle().bigText(getString(R.string.root_proxy_start_failed_text)))
+            .setSmallIcon(R.drawable.ic_shield_off)
+            .setOngoing(false)
+            .setContentIntent(pendingIntent)
+            .addAction(
+                Notification.Action.Builder(
+                    null, getString(R.string.vpn_stopped_action_enable), retryPendingIntent
+                ).build()
+            )
+            .build()
+
+        val notificationManager = getSystemService(NotificationManager::class.java)
+        notificationManager.notify(NOTIFICATION_ID, notification)
+    }
+
     private fun startNotificationUpdates() {
         notificationUpdateJob?.cancel()
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -503,6 +503,8 @@
     <string name="settings_root_proxy_desc">Redirect DNS via iptables instead of VPN (requires Root)</string>
     <string name="root_not_available">Root access not available. Please grant permission in your root manager (e.g., Magisk/KernelSU).</string>
     <string name="root_proxy_notification_text">Root Proxy mode active — DNS traffic redirected via iptables</string>
+    <string name="root_proxy_start_failed_title">BlockAds failed to start</string>
+    <string name="root_proxy_start_failed_text">Could not get root access to start protection. Tap Enable to retry.</string>
     <string name="reddit_link" translatable="false">https://www.reddit.com/r/BlockAds/</string>
     <string name="telegram_link" translatable="false">https://t.me/blockads_android</string>
     <string name="test_block_link" translatable="false">https://adblock.turtlecute.org/</string>


### PR DESCRIPTION
## Problem
With auto-reconnect + Root Proxy mode enabled, protection does not come back after a reboot — the app shows *Unprotected* until started manually (#179).

## Root cause
libsu caches the main shell for the process lifetime. `RootProxyService` starts within seconds of `BOOT_COMPLETED`, so its first shell command usually runs **before the Magisk/KernelSU daemon is ready** — libsu silently falls back to a non-root `sh` and caches it. All 10 retries then reuse the poisoned non-root shell, so `iptables` fails every time (total retry window was only ~37s), after which the service stops silently.

## Changes
- **`IptablesManager.ensureRootShell()`** — if the cached main shell is non-root, close it and rebuild so libsu re-attempts `su`; each retry attempt is now gated on this (also skips pointless Go-engine start/stop churn while root isn't available).
- **Longer boot retry budget** — 30 attempts (~2.5 min) when started with `EXTRA_STARTED_FROM_BOOT`, 10 otherwise. The previously unused `startedFromBoot` parameter is now actually used.
- **Failure notification** — when all retries are exhausted, show "BlockAds failed to start — tap Enable to retry" instead of dying silently.

## Testing
- `:app:compileDebugKotlin` passes.
- Needs on-device verification on a rooted device: reboot with Root Proxy + auto-reconnect enabled → protection should come up within ~1–2 min; logcat should show "Recreated libsu main shell, isRoot=true" on early attempts.

Fixes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated startup failure notification that displays when root access cannot be obtained, with a retry action to recover.

* **Bug Fixes**
  * Improved root access detection and refresh during service startup to prevent reusing stale or non-functional shell states.
  * Enhanced error handling and user feedback when the protection service fails to start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->