### PR TITLE
fix: VPN reports metered network — breaks Wi-Fi-only apps (#171, #156, #177)

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/service/AdBlockVpnService.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/AdBlockVpnService.kt
@@ -663,6 +663,13 @@ class AdBlockVpnService : VpnService() {
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 builder.setUnderlyingNetworks(null)
+                // VPN networks are METERED by default on Android 10+. Apps
+                // with "Wi-Fi only" download settings (OneDrive, Audible,
+                // torrent clients, ...) check NOT_METERED, so they refuse to
+                // work while the VPN is up even on Wi-Fi. Inherit meteredness
+                // from the underlying network instead (Wi-Fi stays unmetered,
+                // cellular stays metered).
+                builder.setMetered(false)
             }
 
             vpnInterface = builder.establish()


### PR DESCRIPTION
## Problem
Multiple reports of apps believing there is **no Wi-Fi** while BlockAds is active:
- #171 — Storytell / Speedtest / Flud refuse to go online ("no wifi connection")
- #156 — OneDrive camera backup silently stops (nothing in BlockAds block logs)
- #177 — Audible downloads fail until BlockAds is paused

## Root cause
Since Android 10, a VPN network is **metered by default** unless the VPN app calls `VpnService.Builder.setMetered(false)` — and `establishVpn()` never did. Apps with "Wi-Fi only" download settings actually check `NET_CAPABILITY_NOT_METERED` on the active network, so with the BlockAds TUN up they see a metered network even on Wi-Fi and refuse to download. Apps that don't gate on meteredness (WhatsApp, Telegram) keep working, which matches the user reports exactly.

## Change
One-line behavior fix in `AdBlockVpnService.establishVpn()`: call `builder.setMetered(false)` (API 29+, guarded) so the VPN **inherits meteredness from the underlying network** — Wi-Fi reports unmetered again, cellular correctly stays metered.

## Testing
- `:app:compileDebugKotlin` passes.
- On-device check: enable BlockAds on Wi-Fi → `adb shell cmd netpolicy list` / any "Wi-Fi only" app (e.g. OneDrive camera backup) should now work; on mobile data the network must still report metered.

Note: #166 (device IP shown as 10.0.0.2) is a related report but is inherent to how TUN interfaces work — will follow up separately on that issue.

Fixes #171
Fixes #156
Fixes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VPN connection classification to ensure proper handling of data metering on newer Android devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->