### PR TITLE
fix: power button invisible to D-pad focus on Android TV (#158)

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/ui/home/component/PowerButton.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/home/component/PowerButton.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -93,6 +94,12 @@ fun PowerButton(
         label = "pulseScale"
     )
 
+    // Track focus so the button is visibly highlighted when navigated to
+    // with a D-pad/remote (Android TV) or keyboard — without this, focus
+    // lands on the button but nothing on screen indicates it (#158).
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier.size(180.dp)
@@ -112,6 +119,19 @@ fun PowerButton(
                     )
                 )
         )
+
+        // Focus ring (visible only while focused via D-pad/keyboard)
+        if (isFocused) {
+            Box(
+                modifier = Modifier
+                    .size(158.dp)
+                    .border(
+                        width = 3.dp,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        shape = CircleShape
+                    )
+            )
+        }
 
         // Main button
         Box(
@@ -145,7 +165,7 @@ fun PowerButton(
                     shape = CircleShape
                 )
                 .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
+                    interactionSource = interactionSource,
                     indication = null,
                     enabled = !isConnecting
                 ) { onClick() }


### PR DESCRIPTION
## Problem
On Smart TVs the Start (power) button can't be "selected" with the remote (#158). A second user confirmed clicking it with a mouse works — so the click handler is fine, the problem is focus feedback.

## Root cause
`PowerButton` uses `clickable(indication = null)` and has no focused-state styling. `clickable` does make the element focusable, so D-pad focus actually lands on the button — but nothing on screen changes, making it impossible to tell it's selected (or that pressing OK would activate it).

## Change
- Hoist the `MutableInteractionSource` and observe `collectIsFocusedAsState()`
- Draw a visible circular focus ring around the button while focused (D-pad/keyboard only — touch interaction is unchanged, ring never appears for taps)

## Testing
- `:app:compileDebugKotlin` passes.
- Needs verification on a TV/emulator with D-pad: navigating to the button should now show a ring; OK/center press toggles protection.

Fixes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PowerButton now provides visual feedback by displaying a focus indicator when navigated using keyboard or D-pad controls, improving the navigation experience for keyboard-driven interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->