### PR TITLE
fix: per-app whitelist had no effect in Root Proxy mode (#150)

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/service/IptablesManager.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/IptablesManager.kt
@@ -65,11 +65,18 @@ object IptablesManager {
      *
      * @param context App context (used to get UID)
      * @param blockDoT If true, blocks DoT (port 853) to force DNS fallback to port 53
+     * @param whitelistUids UIDs of whitelisted apps whose DNS must bypass the
+     *        redirect entirely — the Root-mode equivalent of VPN mode's
+     *        addDisallowedApplication (#150)
      * @return true if at least IPv4 rules succeeded
      */
-    fun setupRules(context: Context, blockDoT: Boolean = true): Boolean {
+    fun setupRules(
+        context: Context,
+        blockDoT: Boolean = true,
+        whitelistUids: Collection<Int> = emptyList()
+    ): Boolean {
         val uid = context.applicationInfo.uid
-        Timber.d("Setting up iptables rules for UID=$uid, blockDoT=$blockDoT")
+        Timber.d("Setting up iptables rules for UID=$uid, blockDoT=$blockDoT, whitelistUids=$whitelistUids")
 
         // Always teardown first (idempotent)
         teardownRules()
@@ -93,6 +100,10 @@ object IptablesManager {
             add("iptables -t nat -N $CHAIN 2>/dev/null || true")
             // Skip our own app's traffic (prevents infinite loop)
             add("iptables -t nat -A $CHAIN -m owner --uid-owner $uid -j RETURN")
+            // Skip whitelisted apps — their DNS goes straight upstream
+            for (wUid in whitelistUids) {
+                add("iptables -t nat -A $CHAIN -m owner --uid-owner $wUid -j RETURN")
+            }
             // Redirect UDP DNS → local engine
             add("iptables -t nat -A $CHAIN -p udp --dport 53 -j REDIRECT --to-ports $LOCAL_DNS_PORT")
             // Redirect TCP DNS → local engine
@@ -104,6 +115,9 @@ object IptablesManager {
                 // filter table — DROP port 853 (DoT)
                 add("iptables -t filter -N $CHAIN_FILTER 2>/dev/null || true")
                 add("iptables -t filter -A $CHAIN_FILTER -m owner --uid-owner $uid -j RETURN")
+                for (wUid in whitelistUids) {
+                    add("iptables -t filter -A $CHAIN_FILTER -m owner --uid-owner $wUid -j RETURN")
+                }
                 add("iptables -t filter -A $CHAIN_FILTER -p tcp --dport 853 -j REJECT")
                 add("iptables -t filter -A OUTPUT -j $CHAIN_FILTER")
             }
@@ -131,6 +145,9 @@ object IptablesManager {
         val ipv6Commands = buildList {
             add("ip6tables -t nat -N $CHAIN 2>/dev/null || true")
             add("ip6tables -t nat -A $CHAIN -m owner --uid-owner $uid -j RETURN")
+            for (wUid in whitelistUids) {
+                add("ip6tables -t nat -A $CHAIN -m owner --uid-owner $wUid -j RETURN")
+            }
             add("ip6tables -t nat -A $CHAIN -p udp --dport 53 -j REDIRECT --to-ports $LOCAL_DNS_PORT")
             add("ip6tables -t nat -A $CHAIN -p tcp --dport 53 -j REDIRECT --to-ports $LOCAL_DNS_PORT")
             add("ip6tables -t nat -A OUTPUT -j $CHAIN")
@@ -138,6 +155,9 @@ object IptablesManager {
             if (blockDoT) {
                 add("ip6tables -t filter -N $CHAIN_FILTER 2>/dev/null || true")
                 add("ip6tables -t filter -A $CHAIN_FILTER -m owner --uid-owner $uid -j RETURN")
+                for (wUid in whitelistUids) {
+                    add("ip6tables -t filter -A $CHAIN_FILTER -m owner --uid-owner $wUid -j RETURN")
+                }
                 add("ip6tables -t filter -A $CHAIN_FILTER -p tcp --dport 853 -j REJECT")
                 add("ip6tables -t filter -A OUTPUT -j $CHAIN_FILTER")
             }

--- a/app/src/main/java/app/pwhs/blockads/service/RootProxyService.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/RootProxyService.kt
@@ -114,6 +114,11 @@ class RootProxyService : Service() {
     @Volatile
     private var firewallManager: FirewallManager? = null
 
+    // UIDs of whitelisted apps, excluded from the iptables DNS redirect.
+    // Kept as a field so the watchdog re-applies the same rules (#150).
+    @Volatile
+    private var whitelistedUids: List<Int> = emptyList()
+
     override fun onCreate() {
         super.onCreate()
         val koin = getKoin()
@@ -208,6 +213,19 @@ class RootProxyService : Service() {
                     firewallManager = null
                 }
 
+                // Resolve whitelisted apps to UIDs so iptables skips their
+                // DNS — Root-mode equivalent of VPN mode's
+                // addDisallowedApplication. Without this the whitelist had
+                // no effect at all in Root Proxy mode (#150).
+                whitelistedUids = appPrefs.getWhitelistedAppsSnapshot().mapNotNull { pkg ->
+                    try {
+                        packageManager.getApplicationInfo(pkg, 0).uid
+                    } catch (e: Exception) {
+                        Timber.w("Whitelisted app not found, skipping: $pkg")
+                        null
+                    }
+                }.distinct()
+
                 // 3. Retry loop for Standalone mode and IPTables setup
                 // This is crucial on boot where Magisk `su` might take a few seconds to become available
                 var proxyStarted = false
@@ -222,7 +240,7 @@ class RootProxyService : Service() {
                     } else {
                         val engineStarted = goTunnelAdapter.startStandalone(port = 15353)
                         if (engineStarted) {
-                            if (IptablesManager.setupRules(this@RootProxyService)) {
+                            if (IptablesManager.setupRules(this@RootProxyService, whitelistUids = whitelistedUids)) {
                                 proxyStarted = true
                             } else {
                                 goTunnelAdapter.stop() // stop engine if iptables fails
@@ -364,7 +382,7 @@ class RootProxyService : Service() {
                 // For now, check if iptables rules are still active
                 if (!IptablesManager.isActive()) {
                     Timber.w("iptables rules disappeared — re-applying")
-                    IptablesManager.setupRules(this@RootProxyService)
+                    IptablesManager.setupRules(this@RootProxyService, whitelistUids = whitelistedUids)
                 }
             }
         }


### PR DESCRIPTION
## Problem
Apps added to the whitelist are still blocked when running in Root Proxy mode (#150, Pixel 8 Pro / Android 17 beta / Wild KSU, log attached by reporter).

## Root cause
The per-app whitelist is only implemented for VPN mode (`AdBlockVpnService.establishVpn()` → `addDisallowedApplication`). `RootProxyService` never reads `whitelistedApps` and the `BLOCKADS_DNS` iptables chain redirects port-53 traffic for **every UID except BlockAds itself** — so in Root mode the whitelist setting did nothing. The reporter's log confirms protection runs normally (iptables SUCCESS) with no whitelist handling anywhere.

## Change
- `IptablesManager.setupRules()` takes a `whitelistUids` collection and inserts `-m owner --uid-owner <uid> -j RETURN` rules **before** the port-53 REDIRECT and the DoT (853) REJECT, in both `iptables` and `ip6tables` chains — the kernel-level equivalent of VPN mode's `addDisallowedApplication`, no per-query UID resolution needed.
- `RootProxyService.startProxy()` resolves whitelisted packages → UIDs and passes them in; the watchdog re-applies the same list when rules disappear.
- Whitelist toggles already restart the running service (`ServiceController.requestRestart`), so changes take effect immediately.

## Testing
- `:app:compileDebugKotlin` passes.
- On-device (rooted): enable Root Proxy, whitelist an app → `su -c iptables -t nat -L BLOCKADS_DNS -n` should show a RETURN rule with that app's UID, and the app's DNS should reach upstream unfiltered; un-whitelist → rule gone after auto-restart.

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to whitelist specific applications, which will be excluded from ad-blocking and DNS filtering features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->