### PR TITLE
fix: resolve all lint errors (translations, NonObservableLocale) + Gradle 8.14.3

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/ui/home/HomeScreen.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/home/HomeScreen.kt
@@ -326,7 +326,7 @@ fun HomeScreen(
                             color = TextSecondary
                         )
                         Text(
-                            text = "${String.format(Locale.getDefault(), "%.1f", blockRate)}%",
+                            text = "${String.format(androidx.compose.ui.text.intl.Locale.current.platformLocale, "%.1f", blockRate)}%",
                             style = MaterialTheme.typography.headlineSmall,
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onBackground

--- a/app/src/main/java/app/pwhs/blockads/ui/statistics/StatisticsScreen.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/statistics/StatisticsScreen.kt
@@ -220,7 +220,7 @@ fun StatisticsScreen(
                             color = TextSecondary
                         )
                         Text(
-                            text = "${String.format(Locale.getDefault(), "%.1f", blockRate)}%",
+                            text = "${String.format(androidx.compose.ui.text.intl.Locale.current.platformLocale, "%.1f", blockRate)}%",
                             style = MaterialTheme.typography.headlineSmall,
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onBackground

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -523,4 +523,6 @@
     <string name="https_filtering_cert_saved_legacy">تم حفظ الشهادة. ثبتها من مدير الملفات.</string>
     <string name="https_filtering_started">بدأت تصفية HTTPS</string>
     <string name="https_filtering_stopped">توقفت تصفية HTTPS</string>
+    <string name="root_proxy_start_failed_title">فشل بدء تشغيل BlockAds</string>
+    <string name="root_proxy_start_failed_text">تعذر الحصول على صلاحية الروت لبدء الحماية. انقر على تفعيل لإعادة المحاولة.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">Certifikát uložen. Nainstalujte ze správce souborů.</string>
     <string name="https_filtering_started">HTTPS filtrování spuštěno</string>
     <string name="https_filtering_stopped">HTTPS filtrování zastaveno</string>
+    <string name="root_proxy_start_failed_title">BlockAds se nepodařilo spustit</string>
+    <string name="root_proxy_start_failed_text">Nepodařilo se získat root oprávnění ke spuštění ochrany. Klepnutím na Povolit to zkuste znovu.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">Zertifikat gespeichert. Installieren Sie es über den Dateimanager.</string>
     <string name="https_filtering_started">HTTPS-Filterung gestartet</string>
     <string name="https_filtering_stopped">HTTPS-Filterung gestoppt</string>
+    <string name="root_proxy_start_failed_title">BlockAds konnte nicht gestartet werden</string>
+    <string name="root_proxy_start_failed_text">Root-Zugriff zum Starten des Schutzes konnte nicht erlangt werden. Tippe auf Aktivieren, um es erneut zu versuchen.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">Certificado guardado. Instálalo desde el gestor de archivos.</string>
     <string name="https_filtering_started">Filtrado HTTPS iniciado</string>
     <string name="https_filtering_stopped">Filtrado HTTPS detenido</string>
+    <string name="root_proxy_start_failed_title">BlockAds no se pudo iniciar</string>
+    <string name="root_proxy_start_failed_text">No se pudo obtener acceso root para iniciar la protección. Toca Activar para reintentar.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">Certificat enregistré. Installez-le depuis le gestionnaire de fichiers.</string>
     <string name="https_filtering_started">Filtrage HTTPS démarré</string>
     <string name="https_filtering_stopped">Filtrage HTTPS arrêté</string>
+    <string name="root_proxy_start_failed_title">Échec du démarrage de BlockAds</string>
+    <string name="root_proxy_start_failed_text">Impossible d\'obtenir l\'accès root pour démarrer la protection. Appuyez sur Activer pour réessayer.</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">Sertifikat disimpan. Instal dari pengelola file.</string>
     <string name="https_filtering_started">Pemfilteran HTTPS dimulai</string>
     <string name="https_filtering_stopped">Pemfilteran HTTPS dihentikan</string>
+    <string name="root_proxy_start_failed_title">BlockAds gagal dimulai</string>
+    <string name="root_proxy_start_failed_text">Tidak bisa mendapatkan akses root untuk memulai perlindungan. Ketuk Aktifkan untuk mencoba lagi.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">Certificato salvato. Installalo dal gestore file.</string>
     <string name="https_filtering_started">Filtro HTTPS avviato</string>
     <string name="https_filtering_stopped">Filtro HTTPS fermato</string>
+    <string name="root_proxy_start_failed_title">Avvio di BlockAds non riuscito</string>
+    <string name="root_proxy_start_failed_text">Impossibile ottenere l\'accesso root per avviare la protezione. Tocca Attiva per riprovare.</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">האישור נשמר. התקן ממנהל הקבצים.</string>
     <string name="https_filtering_started">סינון HTTPS הופעל</string>
     <string name="https_filtering_stopped">סינון HTTPS הופסק</string>
+    <string name="root_proxy_start_failed_title">ההפעלה של BlockAds נכשלה</string>
+    <string name="root_proxy_start_failed_text">לא ניתן לקבל גישת root כדי להפעיל את ההגנה. הקש על הפעלה כדי לנסות שוב.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">証明書を保存しました。ファイルマネージャーからインストールしてください。</string>
     <string name="https_filtering_started">HTTPSフィルタリングを開始</string>
     <string name="https_filtering_stopped">HTTPSフィルタリングを停止</string>
+    <string name="root_proxy_start_failed_title">BlockAds を開始できませんでした</string>
+    <string name="root_proxy_start_failed_text">保護を開始するための root 権限を取得できませんでした。「有効にする」をタップして再試行してください。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">인증서가 저장됨. 파일 관리자에서 설치하세요.</string>
     <string name="https_filtering_started">HTTPS 필터링 시작됨</string>
     <string name="https_filtering_stopped">HTTPS 필터링 중지됨</string>
+    <string name="root_proxy_start_failed_title">BlockAds를 시작하지 못했습니다</string>
+    <string name="root_proxy_start_failed_text">보호를 시작하기 위한 루트 권한을 얻지 못했습니다. 다시 시도하려면 사용을 누르세요.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">Certyfikat zapisany. Zainstaluj z menedżera plików.</string>
     <string name="https_filtering_started">Filtrowanie HTTPS uruchomione</string>
     <string name="https_filtering_stopped">Filtrowanie HTTPS zatrzymane</string>
+    <string name="root_proxy_start_failed_title">Nie udało się uruchomić BlockAds</string>
+    <string name="root_proxy_start_failed_text">Nie udało się uzyskać dostępu root, aby uruchomić ochronę. Stuknij Włącz, aby spróbować ponownie.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">Certificado salvo. Instale pelo gerenciador de arquivos.</string>
     <string name="https_filtering_started">Filtragem HTTPS iniciada</string>
     <string name="https_filtering_stopped">Filtragem HTTPS parada</string>
+    <string name="root_proxy_start_failed_title">Falha ao iniciar o BlockAds</string>
+    <string name="root_proxy_start_failed_text">Não foi possível obter acesso root para iniciar a proteção. Toque em Ativar para tentar novamente.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">Сертификат сохранён. Установите его через файловый менеджер.</string>
     <string name="https_filtering_started">HTTPS-фильтрация запущена</string>
     <string name="https_filtering_stopped">HTTPS-фильтрация остановлена</string>
+    <string name="root_proxy_start_failed_title">Не удалось запустить BlockAds</string>
+    <string name="root_proxy_start_failed_text">Не удалось получить root-доступ для запуска защиты. Нажмите «Включить», чтобы повторить попытку.</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">บันทึกใบรับรองแล้ว ติดตั้งจากตัวจัดการไฟล์</string>
     <string name="https_filtering_started">เริ่มการกรอง HTTPS แล้ว</string>
     <string name="https_filtering_stopped">หยุดการกรอง HTTPS แล้ว</string>
+    <string name="root_proxy_start_failed_title">BlockAds เริ่มทำงานไม่สำเร็จ</string>
+    <string name="root_proxy_start_failed_text">ไม่สามารถรับสิทธิ์รูทเพื่อเริ่มการป้องกันได้ แตะ เปิดใช้งาน เพื่อลองอีกครั้ง</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -528,4 +528,6 @@ Desteklenen formatlar:
     <string name="https_filtering_cert_saved_legacy">Sertifika kaydedildi. Dosya yöneticisinden yükleyin.</string>
     <string name="https_filtering_started">HTTPS filtreleme başlatıldı</string>
     <string name="https_filtering_stopped">HTTPS filtreleme durduruldu</string>
+    <string name="root_proxy_start_failed_title">BlockAds başlatılamadı</string>
+    <string name="root_proxy_start_failed_text">Korumayı başlatmak için root erişimi alınamadı. Yeniden denemek için Etkinleştir\'e dokunun.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">Сертифікат збережено. Встановіть через файловий менеджер.</string>
     <string name="https_filtering_started">HTTPS-фільтрацію розпочато</string>
     <string name="https_filtering_stopped">HTTPS-фільтрацію зупинено</string>
+    <string name="root_proxy_start_failed_title">Не вдалося запустити BlockAds</string>
+    <string name="root_proxy_start_failed_text">Не вдалося отримати root-доступ для запуску захисту. Натисніть «Увімкнути», щоб повторити спробу.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">Đã lưu chứng chỉ. Hãy cài đặt từ trình quản lý tệp.</string>
     <string name="https_filtering_started">Đã bật lọc HTTPS</string>
     <string name="https_filtering_stopped">Đã tắt lọc HTTPS</string>
+    <string name="root_proxy_start_failed_title">BlockAds không thể khởi động</string>
+    <string name="root_proxy_start_failed_text">Không thể lấy quyền root để bật bảo vệ. Nhấn Bật để thử lại.</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -507,4 +507,6 @@
     <string name="https_filtering_cert_saved_legacy">证书已保存，请从文件管理器安装。</string>
     <string name="https_filtering_started">HTTPS 过滤已启动</string>
     <string name="https_filtering_stopped">HTTPS 过滤已停止</string>
+    <string name="root_proxy_start_failed_title">BlockAds 启动失败</string>
+    <string name="root_proxy_start_failed_text">无法获取 Root 权限以启动防护。点按“启用”重试。</string>
 </resources>

--- a/blockadstv/src/main/java/app/pwhs/blockadstv/ui/screens/home/HomeScreen.kt
+++ b/blockadstv/src/main/java/app/pwhs/blockadstv/ui/screens/home/HomeScreen.kt
@@ -199,7 +199,7 @@ fun HomeScreen(
             StatCard(
                 icon = Icons.Default.Shield,
                 label = "Block Rate",
-                value = String.format(Locale.getDefault(), "%.1f%%", blockRate),
+                value = String.format(androidx.compose.ui.text.intl.Locale.current.platformLocale, "%.1f%%", blockRate),
                 modifier = Modifier.weight(1f),
             )
             StatCard(

--- a/blockadstv/src/main/java/app/pwhs/blockadstv/ui/screens/logs/LogsScreen.kt
+++ b/blockadstv/src/main/java/app/pwhs/blockadstv/ui/screens/logs/LogsScreen.kt
@@ -125,7 +125,7 @@ fun LogsScreen(
             if (totalCount > 0) {
                 val rate = blockedCount * 100f / totalCount
                 Text(
-                    text = String.format(Locale.getDefault(), "%.1f%% blocked", rate),
+                    text = String.format(androidx.compose.ui.text.intl.Locale.current.platformLocale, "%.1f%% blocked", rate),
                     style = MaterialTheme.typography.labelLarge,
                     color = TextSecondary,
                 )

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Tue Feb 10 09:38:45 ICT 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## What
`./gradlew lintDebug` was failing with 4 errors in `:app` and 2 in `:blockadstv`; test/lint task creation was also broken when Gradle runs on Java 24.

## Changes
- **MissingTranslation (2 errors):** translated `root_proxy_start_failed_title`/`_text` (added in #180) into all 19 locales (de, ru, ko, pt-rBR, in, it, fr, es, iw, zh, cs, ar, vi, th, uk, ja, pl, tr).
- **NonObservableLocale (4 errors):** replaced `java.util.Locale.getDefault()` with the observable `androidx.compose.ui.text.intl.Locale.current.platformLocale` inside composables — phone `HomeScreen`/`StatisticsScreen` and TV `HomeScreen`/`LogsScreen`.
- **Gradle wrapper 8.13 → 8.14.3:** Gradle 8.13 can't instantiate test/lint report task types on a Java 24 daemon (`DefaultTestTaskReports` failure); 8.14 is the first release supporting Java 24. AGP stays at 8.13.2 (compatible).

## Verification
`:app:lintDebug`, `:blockadstv:lintDebug`, `:app:testDebugUnitTest`, `:app:assembleDebug`, `:blockadstv:assembleDebug` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Improved locale handling for percentage display formatting across the app and TV interface.
  * Added multilingual error messages for root proxy startup failures in 18+ languages.

* **Chores**
  * Updated Gradle wrapper to version 8.14.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->