### PR TITLE
fix: ISP DNS leak in VPN mode — capture all DNS via full route (#145)

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/service/AdBlockVpnService.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/AdBlockVpnService.kt
@@ -621,13 +621,44 @@ class AdBlockVpnService : VpnService() {
                 val b = Builder()
                     .setSession("BlockAds")
                     .addAddress("10.0.0.2", 32)
-                    .addRoute("10.0.0.1", 32)
                     .addDnsServer("10.0.0.1")
                     .addAddress("fd00::2", 128)
-                    .addRoute("fd00::1", 128)
                     .addDnsServer("fd00::1")
                     .setBlocking(true)
                     .setMtu(1500)
+
+                // Full default route so ALL DNS is captured by the engine,
+                // not just the fake DNS IPs. Previously only 10.0.0.1/32 and
+                // fd00::1/128 were routed, which let the system's Private DNS
+                // (DoT, TCP 853) and any app hard-coding a resolver reach the
+                // network DNS outside the tunnel — the ISP-DNS leak in #145.
+                // The userspace engine already handles full capture (same as
+                // WireGuard mode); the fake DNS above forces plain DNS the
+                // engine answers, and non-DNS flows pass through via the
+                // engine's DirectOutbound on protect()ed sockets.
+                b.addRoute("0.0.0.0", 0)
+                b.addRoute("::", 0)
+
+                // Explicit /32 + /128 routes to the fake DNS keep it inside
+                // the tunnel via longest-prefix match even when the LAN
+                // ranges below are excluded.
+                b.addRoute("10.0.0.1", 32)
+                b.addRoute("fd00::1", 128)
+
+                // Exclude LAN/private ranges so local servers remain reachable
+                // (also issue #104). Mirrors the WireGuard branch.
+                val excludeLan = runBlocking { appPrefs.excludeLan.first() }
+                if (excludeLan && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    try {
+                        b.excludeRoute(android.net.IpPrefix(java.net.InetAddress.getByName("10.0.0.0"), 8))
+                        b.excludeRoute(android.net.IpPrefix(java.net.InetAddress.getByName("172.16.0.0"), 12))
+                        b.excludeRoute(android.net.IpPrefix(java.net.InetAddress.getByName("192.168.0.0"), 16))
+                        b.excludeRoute(android.net.IpPrefix(java.net.InetAddress.getByName("169.254.0.0"), 16))
+                        Timber.d("LAN excluded from DNS-only VPN routes")
+                    } catch (e: Exception) {
+                        Timber.w(e, "Failed to exclude LAN routes")
+                    }
+                }
 
                 if (httpsFilteringEnabled) {
                     // Route the synthetic IP range used for the local
@@ -664,9 +695,9 @@ class AdBlockVpnService : VpnService() {
                 }
             }
 
-            if (wgConfig == null) {
-                builder.allowBypass()
-            }
+            // Note: allowBypass() is intentionally NOT set. It lets apps open
+            // sockets that skip the VPN, which in DNS-only full-route mode
+            // would re-open the DNS leak path this fix closes (#145).
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 builder.setUnderlyingNetworks(null)


### PR DESCRIPTION
## Problem
With a DoH upstream configured (e.g. RethinkDNS), a DNS-leak test still shows the **ISP's** DNS servers in VPN mode (#145).

## Root cause
DNS-only VPN mode built a TUN that only routed the *fake* DNS IPs (`10.0.0.1/32`, `fd00::1/128`). Anything doing DNS to a real IP escaped the tunnel:
1. **Android Private DNS (DoT, TCP 853)** — the main cause. Opportunistic mode is the default on many devices, so the system resolver opens TLS/853 directly to the **network's real DNS server**, which wasn't in the route table → went out the underlying network → ISP DNS visible on dnsleaktest. The fake `10.0.0.1` was bypassed entirely.
2. Apps hard-coding a resolver (e.g. `8.8.8.8`) — that IP wasn't routed → leaked.

Root Proxy mode doesn't leak because it disables `private_dns_mode` via `su` + REJECTs 853 in iptables — but that needs root and isn't available in VPN mode. (Note: `Settings.Global.putString(private_dns_mode,"off")` is **not** an option here — it needs `WRITE_SECURE_SETTINGS`, which a non-root app can't hold.)

## Fix — match AdGuard / the existing WireGuard branch
The Go engine (`tunnel.aar`) is a full userspace TCP/IP stack and **already does full capture in WireGuard mode** (`0.0.0.0/0` + `::/0` + fake DNS to defeat DoT). DNS-only mode now does the same:
- Route `0.0.0.0/0` and `::/0` through the TUN so DoT/853 and hard-coded resolvers are all captured.
- Keep the fake DNS servers; explicit `10.0.0.1/32` + `fd00::1/128` routes win longest-prefix so the fake DNS stays in-tunnel even with the LAN excludes.
- Reuse the WireGuard branch's `excludeLan` logic (10/8, 172.16/12, 192.168/16, 169.254/16 on API 33+) so local servers stay reachable (also helps #104).
- Remove `allowBypass()` for this mode — it let apps skip the TUN, re-opening the leak.

Non-DNS traffic is forwarded by the engine's `DirectOutbound` over `protect()`ed sockets, same as WireGuard mode.

## Testing
- `:app:assembleDebug` + `:app:lintDebug` pass.
- **Needs on-device verification:** VPN mode + DoH upstream → https://dnsleaktest.com (Extended) should show only the DoH provider, not the ISP, with Android Private DNS = Off **and** Opportunistic. Confirm general browsing / IPv6 / a "Wi-Fi only" app still work, LAN devices reachable, and whitelisted apps still bypass.

## Follow-up (not in this PR)
Private DNS **Strict** can't be transparently captured (DoT is mandatory); the connection won't leak to the ISP but won't be ad-filtered either. A small in-app warning when Strict is detected (`LinkProperties.isPrivateDnsActive`) is a good follow-up — deferred because it needs new user-facing strings across all 19 locales.

Fixes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN traffic routing to ensure all traffic flows through the tunnel, preventing DNS leaks.
  * Removed unintended DNS bypass behavior in direct VPN mode for enhanced security.

* **New Features**
  * Added option to exclude local area networks and private address ranges from VPN routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->