### PR TITLE
ci: fix dex-merge OutOfMemoryError (raise Gradle heap to 4g)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Problem
CI `Build debug APK` fails with `java.lang.OutOfMemoryError: Java heap space` during dex merge (`:blockadstv:mergeExtDexDebug` and `:app:packageDebug`). [Failed run](https://github.com/pass-with-high-score/blockads-android/actions/runs/27362027515/job/80851616827)

## Cause
Not a code error. After the Android TV module landed (#185), `assembleDebug` builds **two** app modules — `app` and `blockadstv` — each bundling a ~14 MB `tunnel.aar`. Merging dex for both at once blew past the 2048m daemon heap.

## Fix
Raise `org.gradle.jvmargs` to `-Xmx4096m -XX:MaxMetaspaceSize=1g` in `gradle.properties`. The CI runner (ubuntu-latest) has plenty of RAM.

## Verification
`./gradlew clean assembleDebug` (both modules) builds successfully locally with the new heap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Gradle build configuration to improve build performance and stability by increasing memory allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->