### PR TITLE
feat: Private DNS conflict warning (learned from AdGuard) (#145)

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/service/AdBlockVpnService.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/AdBlockVpnService.kt
@@ -125,6 +125,23 @@ class AdBlockVpnService : VpnService() {
         var lastStoppedTimestamp = 0L
             private set
 
+        /** True when Android Private DNS is in Strict ("hostname") mode on the
+         *  active network. In that mode the system resolver does mandatory DoT
+         *  to a fixed server, bypassing BlockAds' DNS interception entirely —
+         *  so filtering silently doesn't apply. The UI surfaces a warning
+         *  (no-root VPN mode cannot disable Private DNS; see #145). */
+        private val _privateDnsStrict = MutableStateFlow(false)
+        val privateDnsStrict: StateFlow<Boolean> = _privateDnsStrict.asStateFlow()
+
+        /** Update [privateDnsStrict] from the active network's LinkProperties. */
+        fun updatePrivateDnsState(linkProperties: android.net.LinkProperties?) {
+            _privateDnsStrict.value = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                linkProperties?.privateDnsServerName != null
+            } else {
+                false
+            }
+        }
+
         /**
          * Request a VPN restart to apply new settings.
          * Only restarts if the VPN is currently running.
@@ -224,6 +241,8 @@ class AdBlockVpnService : VpnService() {
             onNetworkAvailable = { onNetworkAvailable() },
             onNetworkLost = { onNetworkLost() },
             onLinkPropertiesChanged = { linkProperties ->
+                // Surface Private DNS (Strict/DoT) which bypasses filtering (#145)
+                updatePrivateDnsState(linkProperties)
                 serviceScope.launch {
                     val providerId = appPrefs.dnsProviderId.first()
                     if (providerId == "system") {
@@ -423,6 +442,11 @@ class AdBlockVpnService : VpnService() {
                 isReconnecting = false
                 _state.value = VpnState.RUNNING
                 appPrefs.setVpnEnabled(true)
+                // Initial Private DNS check (callback only fires on change)
+                runCatching {
+                    val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+                    updatePrivateDnsState(cm.activeNetwork?.let { cm.getLinkProperties(it) })
+                }
                 if (!resumedFromReconnect) {
                     vpnStartTime = System.currentTimeMillis()
                 }
@@ -856,6 +880,7 @@ class AdBlockVpnService : VpnService() {
             withContext(Dispatchers.Main) {
                 _state.value = VpnState.STOPPED
                 lastStoppedTimestamp = System.currentTimeMillis()
+                _privateDnsStrict.value = false
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 if (showStoppedNotification) {
                     stopForeground(STOP_FOREGROUND_DETACH)

--- a/app/src/main/java/app/pwhs/blockads/ui/home/HomeScreen.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/home/HomeScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.GppGood
 import androidx.compose.material.icons.filled.QueryStats
 import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -110,6 +111,7 @@ fun HomeScreen(
     val activeProfile by viewModel.activeProfile.collectAsStateWithLifecycle()
     val securityFilterIds by viewModel.securityFilterIds.collectAsStateWithLifecycle()
     val routingMode by viewModel.routingMode.collectAsStateWithLifecycle()
+    val privateDnsWarning by viewModel.privateDnsWarning.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     LaunchedEffect(Unit) {
@@ -138,6 +140,42 @@ fun HomeScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Spacer(modifier = Modifier.height(16.dp))
+
+            // Private DNS warning — DoT bypasses BlockAds filtering (#145)
+            if (privateDnsWarning) {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 16.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Warning,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column {
+                            Text(
+                                text = stringResource(R.string.private_dns_warning_title),
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer
+                            )
+                            Text(
+                                text = stringResource(R.string.private_dns_warning_text),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer
+                            )
+                        }
+                    }
+                }
+            }
 
             // Status text
             Text(

--- a/app/src/main/java/app/pwhs/blockads/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/home/HomeViewModel.kt
@@ -108,6 +108,18 @@ class HomeViewModel(
     val domainCount: StateFlow<Int> = filterRepo.domainCountFlow
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), filterRepo.domainCount)
 
+    // Warn when protection is on in VPN mode but Android Private DNS (Strict
+    // DoT) is active — it bypasses BlockAds' DNS interception, so filtering
+    // silently doesn't apply. Root Proxy mode disables Private DNS itself, so
+    // the warning is VPN-mode only (#145).
+    val privateDnsWarning: StateFlow<Boolean> = combine(
+        vpnEnabled,
+        routingMode,
+        AdBlockVpnService.privateDnsStrict
+    ) { enabled, mode, strict ->
+        enabled && mode != AppPreferences.ROUTING_MODE_ROOT && strict
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
     init {
         // Uptime ticker — only ticks while VPN or Root Proxy is RUNNING
         viewModelScope.launch {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -525,4 +525,6 @@
     <string name="https_filtering_stopped">توقفت تصفية HTTPS</string>
     <string name="root_proxy_start_failed_title">فشل بدء تشغيل BlockAds</string>
     <string name="root_proxy_start_failed_text">تعذر الحصول على صلاحية الروت لبدء الحماية. انقر على تفعيل لإعادة المحاولة.</string>
+    <string name="private_dns_warning_title">‏DNS الخاص مُفعّل</string>
+    <string name="private_dns_warning_text">‏يتجاوز DNS الخاص في Android تطبيق BlockAds، لذا قد لا تُطبَّق التصفية. اضبط DNS الخاص على إيقاف أو تلقائي من إعدادات النظام.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">HTTPS filtrování zastaveno</string>
     <string name="root_proxy_start_failed_title">BlockAds se nepodařilo spustit</string>
     <string name="root_proxy_start_failed_text">Nepodařilo se získat root oprávnění ke spuštění ochrany. Klepnutím na Povolit to zkuste znovu.</string>
+    <string name="private_dns_warning_title">Soukromé DNS je zapnuté</string>
+    <string name="private_dns_warning_text">Soukromé DNS systému Android obchází BlockAds, takže filtrování nemusí fungovat. Nastavte soukromé DNS na Vypnuto nebo Automaticky v nastavení systému.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">HTTPS-Filterung gestoppt</string>
     <string name="root_proxy_start_failed_title">BlockAds konnte nicht gestartet werden</string>
     <string name="root_proxy_start_failed_text">Root-Zugriff zum Starten des Schutzes konnte nicht erlangt werden. Tippe auf Aktivieren, um es erneut zu versuchen.</string>
+    <string name="private_dns_warning_title">Privates DNS ist aktiv</string>
+    <string name="private_dns_warning_text">Android Privates DNS umgeht BlockAds, daher greift die Filterung evtl. nicht. Stelle Privates DNS in den Systemeinstellungen auf Aus oder Automatisch.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">Filtrado HTTPS detenido</string>
     <string name="root_proxy_start_failed_title">BlockAds no se pudo iniciar</string>
     <string name="root_proxy_start_failed_text">No se pudo obtener acceso root para iniciar la protección. Toca Activar para reintentar.</string>
+    <string name="private_dns_warning_title">DNS privado activado</string>
+    <string name="private_dns_warning_text">El DNS privado de Android omite BlockAds, por lo que el filtrado puede no aplicarse. Configura el DNS privado como Desactivado o Automático en los ajustes del sistema.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">Filtrage HTTPS arrêté</string>
     <string name="root_proxy_start_failed_title">Échec du démarrage de BlockAds</string>
     <string name="root_proxy_start_failed_text">Impossible d\'obtenir l\'accès root pour démarrer la protection. Appuyez sur Activer pour réessayer.</string>
+    <string name="private_dns_warning_title">DNS privé activé</string>
+    <string name="private_dns_warning_text">Le DNS privé d\'Android contourne BlockAds, le filtrage peut donc ne pas s\'appliquer. Réglez le DNS privé sur Désactivé ou Automatique dans les paramètres système.</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">Pemfilteran HTTPS dihentikan</string>
     <string name="root_proxy_start_failed_title">BlockAds gagal dimulai</string>
     <string name="root_proxy_start_failed_text">Tidak bisa mendapatkan akses root untuk memulai perlindungan. Ketuk Aktifkan untuk mencoba lagi.</string>
+    <string name="private_dns_warning_title">DNS Pribadi aktif</string>
+    <string name="private_dns_warning_text">DNS Pribadi Android melewati BlockAds, sehingga pemfilteran mungkin tidak diterapkan. Setel DNS Pribadi ke Nonaktif atau Otomatis di setelan sistem.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">Filtro HTTPS fermato</string>
     <string name="root_proxy_start_failed_title">Avvio di BlockAds non riuscito</string>
     <string name="root_proxy_start_failed_text">Impossibile ottenere l\'accesso root per avviare la protezione. Tocca Attiva per riprovare.</string>
+    <string name="private_dns_warning_title">DNS privato attivo</string>
+    <string name="private_dns_warning_text">Il DNS privato di Android aggira BlockAds, quindi il filtraggio potrebbe non essere applicato. Imposta il DNS privato su Disattivato o Automatico nelle impostazioni di sistema.</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">סינון HTTPS הופסק</string>
     <string name="root_proxy_start_failed_title">ההפעלה של BlockAds נכשלה</string>
     <string name="root_proxy_start_failed_text">לא ניתן לקבל גישת root כדי להפעיל את ההגנה. הקש על הפעלה כדי לנסות שוב.</string>
+    <string name="private_dns_warning_title">‏DNS פרטי פעיל</string>
+    <string name="private_dns_warning_text">‏DNS פרטי של Android עוקף את BlockAds, ולכן הסינון עלול לא לחול. הגדירו את ה-DNS הפרטי לכבוי או אוטומטי בהגדרות המערכת.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">HTTPSフィルタリングを停止</string>
     <string name="root_proxy_start_failed_title">BlockAds を開始できませんでした</string>
     <string name="root_proxy_start_failed_text">保護を開始するための root 権限を取得できませんでした。「有効にする」をタップして再試行してください。</string>
+    <string name="private_dns_warning_title">プライベート DNS が有効です</string>
+    <string name="private_dns_warning_text">Android のプライベート DNS は BlockAds を迂回するため、フィルタリングが適用されないことがあります。システム設定でプライベート DNS をオフまたは自動に設定してください。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">HTTPS 필터링 중지됨</string>
     <string name="root_proxy_start_failed_title">BlockAds를 시작하지 못했습니다</string>
     <string name="root_proxy_start_failed_text">보호를 시작하기 위한 루트 권한을 얻지 못했습니다. 다시 시도하려면 사용을 누르세요.</string>
+    <string name="private_dns_warning_title">비공개 DNS가 켜져 있습니다</string>
+    <string name="private_dns_warning_text">Android 비공개 DNS는 BlockAds를 우회하므로 필터링이 적용되지 않을 수 있습니다. 시스템 설정에서 비공개 DNS를 끄거나 자동으로 설정하세요.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">Filtrowanie HTTPS zatrzymane</string>
     <string name="root_proxy_start_failed_title">Nie udało się uruchomić BlockAds</string>
     <string name="root_proxy_start_failed_text">Nie udało się uzyskać dostępu root, aby uruchomić ochronę. Stuknij Włącz, aby spróbować ponownie.</string>
+    <string name="private_dns_warning_title">Prywatny DNS jest włączony</string>
+    <string name="private_dns_warning_text">Prywatny DNS systemu Android omija BlockAds, więc filtrowanie może nie działać. Ustaw prywatny DNS na Wyłączony lub Automatyczny w ustawieniach systemu.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">Filtragem HTTPS parada</string>
     <string name="root_proxy_start_failed_title">Falha ao iniciar o BlockAds</string>
     <string name="root_proxy_start_failed_text">Não foi possível obter acesso root para iniciar a proteção. Toque em Ativar para tentar novamente.</string>
+    <string name="private_dns_warning_title">DNS privado está ativado</string>
+    <string name="private_dns_warning_text">O DNS privado do Android ignora o BlockAds, então a filtragem pode não ser aplicada. Defina o DNS privado como Desativado ou Automático nas configurações do sistema.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">HTTPS-фильтрация остановлена</string>
     <string name="root_proxy_start_failed_title">Не удалось запустить BlockAds</string>
     <string name="root_proxy_start_failed_text">Не удалось получить root-доступ для запуска защиты. Нажмите «Включить», чтобы повторить попытку.</string>
+    <string name="private_dns_warning_title">Частный DNS включён</string>
+    <string name="private_dns_warning_text">Частный DNS Android обходит BlockAds, поэтому фильтрация может не работать. Установите «Частный DNS» в значение «Выкл.» или «Автоматически» в настройках системы.</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">หยุดการกรอง HTTPS แล้ว</string>
     <string name="root_proxy_start_failed_title">BlockAds เริ่มทำงานไม่สำเร็จ</string>
     <string name="root_proxy_start_failed_text">ไม่สามารถรับสิทธิ์รูทเพื่อเริ่มการป้องกันได้ แตะ เปิดใช้งาน เพื่อลองอีกครั้ง</string>
+    <string name="private_dns_warning_title">เปิด DNS ส่วนตัวอยู่</string>
+    <string name="private_dns_warning_text">DNS ส่วนตัวของ Android จะข้าม BlockAds การกรองจึงอาจไม่ทำงาน โปรดตั้งค่า DNS ส่วนตัวเป็นปิดหรืออัตโนมัติในการตั้งค่าระบบ</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -530,4 +530,6 @@ Desteklenen formatlar:
     <string name="https_filtering_stopped">HTTPS filtreleme durduruldu</string>
     <string name="root_proxy_start_failed_title">BlockAds başlatılamadı</string>
     <string name="root_proxy_start_failed_text">Korumayı başlatmak için root erişimi alınamadı. Yeniden denemek için Etkinleştir\'e dokunun.</string>
+    <string name="private_dns_warning_title">Özel DNS açık</string>
+    <string name="private_dns_warning_text">Android Özel DNS, BlockAds\'i atlar; bu nedenle filtreleme uygulanmayabilir. Sistem ayarlarından Özel DNS\'i Kapalı veya Otomatik yapın.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">HTTPS-фільтрацію зупинено</string>
     <string name="root_proxy_start_failed_title">Не вдалося запустити BlockAds</string>
     <string name="root_proxy_start_failed_text">Не вдалося отримати root-доступ для запуску захисту. Натисніть «Увімкнути», щоб повторити спробу.</string>
+    <string name="private_dns_warning_title">Приватний DNS увімкнено</string>
+    <string name="private_dns_warning_text">Приватний DNS Android обходить BlockAds, тож фільтрування може не застосовуватися. Установіть приватний DNS на «Вимкнено» або «Автоматично» в налаштуваннях системи.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">Đã tắt lọc HTTPS</string>
     <string name="root_proxy_start_failed_title">BlockAds không thể khởi động</string>
     <string name="root_proxy_start_failed_text">Không thể lấy quyền root để bật bảo vệ. Nhấn Bật để thử lại.</string>
+    <string name="private_dns_warning_title">DNS riêng tư đang bật</string>
+    <string name="private_dns_warning_text">DNS riêng tư của Android bỏ qua BlockAds nên việc lọc có thể không áp dụng. Hãy đặt DNS riêng tư về Tắt hoặc Tự động trong cài đặt hệ thống.</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -509,4 +509,6 @@
     <string name="https_filtering_stopped">HTTPS 过滤已停止</string>
     <string name="root_proxy_start_failed_title">BlockAds 启动失败</string>
     <string name="root_proxy_start_failed_text">无法获取 Root 权限以启动防护。点按“启用”重试。</string>
+    <string name="private_dns_warning_title">私人 DNS 已开启</string>
+    <string name="private_dns_warning_text">Android 私人 DNS 会绕过 BlockAds，因此过滤可能不生效。请在系统设置中将私人 DNS 设为“关闭”或“自动”。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -505,6 +505,8 @@
     <string name="root_proxy_notification_text">Root Proxy mode active — DNS traffic redirected via iptables</string>
     <string name="root_proxy_start_failed_title">BlockAds failed to start</string>
     <string name="root_proxy_start_failed_text">Could not get root access to start protection. Tap Enable to retry.</string>
+    <string name="private_dns_warning_title">Private DNS is on</string>
+    <string name="private_dns_warning_text">Android Private DNS bypasses BlockAds, so filtering may not apply. Set Private DNS to Off or Automatic in system settings.</string>
     <string name="reddit_link" translatable="false">https://www.reddit.com/r/BlockAds/</string>
     <string name="telegram_link" translatable="false">https://t.me/blockads_android</string>
     <string name="test_block_link" translatable="false">https://adblock.turtlecute.org/</string>


### PR DESCRIPTION
## What
Adds a Home-screen warning when Android **Private DNS (Strict/DoT)** is active in VPN mode. In that mode the system resolver does mandatory DoT to a fixed server, **bypassing BlockAds' DNS interception** — filtering silently stops working. This is the partial mitigation for #145 after the full-route fix had to be reverted (it broke internet).

## Approach (mirrors AdGuard's PrivateDnsConflictManager)
A no-root VPN app **cannot** disable Private DNS (`WRITE_SECURE_SETTINGS`), so AdGuard detects it and warns the user; we do the same:
- `AdBlockVpnService.privateDnsStrict` StateFlow, set from the active network's `LinkProperties.privateDnsServerName != null` (API 28+) at VPN start and on every `onLinkPropertiesChanged`; cleared on stop.
- `HomeViewModel.privateDnsWarning` = protection on + VPN mode (not Root) + strict.
- `HomeScreen` shows an `errorContainer` banner: *"Private DNS is on — set it to Off or Automatic."*
- Strings added to all 19 locales.

Root Proxy mode already disables Private DNS via `su`, so the warning is VPN-mode only.

## Test
`:app:assembleDebug` + `:app:lintDebug` pass. On device: enable VPN with Settings → Private DNS = a hostname (Strict) → banner appears; set to Off/Automatic → banner clears.

Part of #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and warning for Android Private DNS strict mode that may bypass ad-blocking
  * Warning card now displays in the home screen when Private DNS is active

* **Localization**
  * Added Private DNS warning messages in 17+ languages (Arabic, Chinese, Czech, French, German, Indonesian, Italian, Hebrew, Japanese, Korean, Polish, Portuguese, Russian, Spanish, Thai, Turkish, Ukrainian, Vietnamese)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->