### PR TITLE
feat: optional Full network protection toggle (Settings + Home) (#145, #162)

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/data/datastore/AppPreferences.kt
+++ b/app/src/main/java/app/pwhs/blockads/data/datastore/AppPreferences.kt
@@ -66,6 +66,7 @@ class AppPreferences(private val context: Context) {
         private val KEY_HIDE_FROM_RECENTS = booleanPreferencesKey("hide_from_recents")
         private val KEY_SPLIT_DNS_ZONES = stringPreferencesKey("split_dns_zones")
         private val KEY_EXCLUDE_LAN = booleanPreferencesKey("exclude_lan")
+        private val KEY_FULL_ROUTE_CAPTURE = booleanPreferencesKey("full_route_capture")
 
         const val ROUTING_MODE_DIRECT = "direct"
         const val ROUTING_MODE_WIREGUARD = "wireguard"
@@ -317,6 +318,19 @@ class AppPreferences(private val context: Context) {
 
     val excludeLan: Flow<Boolean> = context.dataStore.data.map { prefs ->
         prefs[KEY_EXCLUDE_LAN] ?: false
+    }
+
+    /**
+     * Full network capture (VPN/Direct mode). Default OFF.
+     * OFF: DNS-only routing — only the fake DNS IPs are captured (safe, the
+     *      proven default; non-DNS traffic flows outside the tunnel).
+     * ON:  route 0.0.0.0/0 + ::/0 and enable the userspace TCP stack so the
+     *      engine forwards non-DNS traffic, capturing Private DNS/DoT leaks
+     *      (#145) and enabling kill-switch compatibility (#162). Opt-in
+     *      because it routes everything through the engine.
+     */
+    val fullRouteCapture: Flow<Boolean> = context.dataStore.data.map { prefs ->
+        prefs[KEY_FULL_ROUTE_CAPTURE] ?: false
     }
 
     suspend fun setVpnEnabled(enabled: Boolean) {
@@ -663,6 +677,16 @@ class AppPreferences(private val context: Context) {
         context.dataStore.edit { prefs ->
             prefs[KEY_EXCLUDE_LAN] = enabled
         }
+    }
+
+    suspend fun setFullRouteCapture(enabled: Boolean) {
+        context.dataStore.edit { prefs ->
+            prefs[KEY_FULL_ROUTE_CAPTURE] = enabled
+        }
+    }
+
+    suspend fun getFullRouteCaptureSnapshot(): Boolean {
+        return context.dataStore.data.map { it[KEY_FULL_ROUTE_CAPTURE] ?: false }.first()
     }
 
     suspend fun setSplitDnsZones(zones: String) {

--- a/app/src/main/java/app/pwhs/blockads/service/AdBlockVpnService.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/AdBlockVpnService.kt
@@ -527,6 +527,10 @@ class AdBlockVpnService : VpnService() {
                 // Read further HTTPS Filtering config (httpsFilteringEnabled is already loaded at the top)
                 val selectedBrowsers = appPrefs.getSelectedBrowsersSnapshot()
                 val certDir = filesDir.absolutePath
+                // Full-route capture only applies to Direct (DNS-only) mode;
+                // WireGuard mode is already full-tunnel via its own config.
+                val forwardAllTraffic = wgConfigJson.isEmpty() &&
+                        appPrefs.getFullRouteCaptureSnapshot()
 
                 vpnInterface?.let {
                     // start() blocks the coroutine while reading from TUN
@@ -537,6 +541,7 @@ class AdBlockVpnService : VpnService() {
                         httpsFilteringEnabled = httpsFilteringEnabled,
                         selectedBrowsers = selectedBrowsers,
                         certDir = certDir,
+                        forwardAllTraffic = forwardAllTraffic,
                         socketProtector = { fd ->
                             try {
                                 protect(fd)
@@ -592,6 +597,9 @@ class AdBlockVpnService : VpnService() {
                     }
                 } else null
 
+            // True when DNS-only mode is set to capture all traffic (toggle).
+            var fullRoute = false
+
             val builder = if (wgConfig != null) {
                 // WireGuard mode — full-route VPN (all traffic through TUN)
                 Timber.d("Establishing VPN in WireGuard mode")
@@ -641,7 +649,8 @@ class AdBlockVpnService : VpnService() {
                 b
             } else {
                 // Direct mode — DNS + (optional) HTTPS local asset host.
-                Timber.d("Establishing VPN in DNS-only mode (httpsFiltering=$httpsFilteringEnabled)")
+                fullRoute = runBlocking { appPrefs.getFullRouteCaptureSnapshot() }
+                Timber.d("Establishing VPN in DNS-only mode (httpsFiltering=$httpsFilteringEnabled, fullRoute=$fullRoute)")
                 val b = Builder()
                     .setSession("BlockAds")
                     .addAddress("10.0.0.2", 32)
@@ -653,15 +662,37 @@ class AdBlockVpnService : VpnService() {
                     .setBlocking(true)
                     .setMtu(1500)
 
-                // DNS-only routing: only the fake DNS IPs are captured. A
-                // full 0.0.0.0/0 route was tried for the #145 DNS-leak fix
-                // but the engine drops non-DNS packets in this mode (it only
-                // forwards when the userspace TCP stack is active for HTTPS
-                // filtering), so full-route blackholed all traffic = no
-                // internet. Reverted to DNS-only. The Private DNS (DoT)
-                // leak is instead surfaced to the user via a warning
-                // (see NetworkMonitor.isPrivateDnsActive); a proper capture
-                // needs engine-level DoT handling (tracked in #145).
+                // Routing depends on the "Full network protection" toggle.
+                //
+                // OFF (default): DNS-only — only the fake DNS IPs above are
+                // captured. Non-DNS traffic flows outside the tunnel. This is
+                // the safe, proven default; the engine drops anything it gets
+                // that isn't DNS, so we must NOT route general traffic here.
+                //
+                // ON: route everything through the engine and enable the
+                // userspace TCP stack (see startVpn → forwardAllTraffic) so
+                // the engine forwards non-DNS flows via DirectOutbound on
+                // protect()ed sockets. This captures Private DNS/DoT leaks
+                // (#145) and is kill-switch compatible (#162). Opt-in because
+                // routing all traffic through the userspace stack is heavier.
+                // The forcing of full-route for everyone in #187 broke
+                // internet — hence the toggle, default OFF.
+                if (fullRoute) {
+                    b.addRoute("0.0.0.0", 0)
+                    b.addRoute("::", 0)
+                    val excludeLan = runBlocking { appPrefs.excludeLan.first() }
+                    if (excludeLan && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        try {
+                            b.excludeRoute(android.net.IpPrefix(java.net.InetAddress.getByName("10.0.0.0"), 8))
+                            b.excludeRoute(android.net.IpPrefix(java.net.InetAddress.getByName("172.16.0.0"), 12))
+                            b.excludeRoute(android.net.IpPrefix(java.net.InetAddress.getByName("192.168.0.0"), 16))
+                            b.excludeRoute(android.net.IpPrefix(java.net.InetAddress.getByName("169.254.0.0"), 16))
+                            Timber.d("LAN excluded from full-route VPN")
+                        } catch (e: Exception) {
+                            Timber.w(e, "Failed to exclude LAN routes")
+                        }
+                    }
+                }
 
                 if (httpsFilteringEnabled) {
                     // Route the synthetic IP range used for the local
@@ -699,9 +730,9 @@ class AdBlockVpnService : VpnService() {
             }
 
             // DNS-only mode allows apps to bypass the tunnel for non-DNS
-            // sockets (we only route the fake DNS IPs anyway). WireGuard
-            // mode is full-tunnel, so no bypass there.
-            if (wgConfig == null) {
+            // sockets (we only route the fake DNS IPs anyway). WireGuard and
+            // full-route capture are full-tunnel, so no bypass there.
+            if (wgConfig == null && !fullRoute) {
                 builder.allowBypass()
             }
 

--- a/app/src/main/java/app/pwhs/blockads/service/GoTunnelAdapter.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/GoTunnelAdapter.kt
@@ -251,15 +251,31 @@ class GoTunnelAdapter(
      * @param certDir Directory to store the proxy's root CA certificate
      */
     fun start(
-        vpnInterface: android.os.ParcelFileDescriptor, 
+        vpnInterface: android.os.ParcelFileDescriptor,
         wgConfigJson: String = "",
         httpsFilteringEnabled: Boolean = false,
         selectedBrowsers: Set<String> = emptySet(),
         certDir: String = "",
+        forwardAllTraffic: Boolean = false,
         socketProtector: ((Int) -> Boolean)? = null
     ) {
         if (isRunning) return
         isRunning = true
+
+        // Full-route capture (DNS-only mode toggle): the TUN now receives ALL
+        // packets, so the engine must forward non-DNS flows instead of
+        // dropping them. Enable the userspace TCP stack (without MITM) so the
+        // engine terminates and forwards TCP via DirectOutbound on protect()ed
+        // sockets. Without this, routing 0.0.0.0/0 blackholes traffic (#187).
+        // When HTTPS filtering is on the stack is already enabled below.
+        if (forwardAllTraffic && !httpsFilteringEnabled) {
+            try {
+                engine.setUseTcpStack(true)
+                Timber.d("Full-route capture: userspace TCP stack enabled for forwarding")
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to enable TCP stack for full-route capture")
+            }
+        }
 
         // 1. Synchronize the MITM state before starting the tunnel.
         // HTTPS filtering now runs through the userspace TCP/IP stack

--- a/app/src/main/java/app/pwhs/blockads/ui/home/HomeScreen.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/home/HomeScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -112,6 +113,7 @@ fun HomeScreen(
     val securityFilterIds by viewModel.securityFilterIds.collectAsStateWithLifecycle()
     val routingMode by viewModel.routingMode.collectAsStateWithLifecycle()
     val privateDnsWarning by viewModel.privateDnsWarning.collectAsStateWithLifecycle()
+    val fullRouteCapture by viewModel.fullRouteCapture.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     LaunchedEffect(Unit) {
@@ -228,6 +230,35 @@ fun HomeScreen(
                     color = MaterialTheme.colorScheme.onPrimaryContainer,
                     fontWeight = FontWeight.SemiBold
                 )
+            }
+
+            // Full network protection toggle — only in Direct (DNS) mode
+            if (routingMode == AppPreferences.ROUTING_MODE_DIRECT) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(R.string.settings_full_route),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Switch(
+                            checked = fullRouteCapture,
+                            onCheckedChange = { viewModel.setFullRouteCapture(context, it) }
+                        )
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/app/pwhs/blockads/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/home/HomeViewModel.kt
@@ -17,6 +17,7 @@ import app.pwhs.blockads.data.repository.FilterListRepository
 import app.pwhs.blockads.service.AdBlockVpnService
 import app.pwhs.blockads.service.VpnState
 import app.pwhs.blockads.service.RootProxyService
+import app.pwhs.blockads.service.ServiceController
 import app.pwhs.blockads.data.datastore.AppPreferences
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,7 +34,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class HomeViewModel(
-    appPrefs: AppPreferences,
+    private val appPrefs: AppPreferences,
     dnsLogDao: DnsLogDao,
     private val filterRepo: FilterListRepository,
     profileDao: ProtectionProfileDao,
@@ -120,6 +121,9 @@ class HomeViewModel(
         enabled && mode != AppPreferences.ROUTING_MODE_ROOT && strict
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
+    val fullRouteCapture: StateFlow<Boolean> = appPrefs.fullRouteCapture
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
     init {
         // Uptime ticker — only ticks while VPN or Root Proxy is RUNNING
         viewModelScope.launch {
@@ -145,6 +149,14 @@ class HomeViewModel(
                 action = AdBlockVpnService.ACTION_STOP
             }
             context.startService(intent)
+        }
+    }
+
+    fun setFullRouteCapture(context: Context, enabled: Boolean) {
+        viewModelScope.launch {
+            appPrefs.setFullRouteCapture(enabled)
+            // Re-establish the tunnel so the new routing applies immediately.
+            ServiceController.requestRestart(context)
         }
     }
 

--- a/app/src/main/java/app/pwhs/blockads/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/settings/SettingsScreen.kt
@@ -69,6 +69,7 @@ fun SettingsScreen(
     val crashReportingEnabled by viewModel.crashReportingEnabled.collectAsStateWithLifecycle()
     val hideFromRecents by viewModel.hideFromRecents.collectAsStateWithLifecycle()
     val routingMode by viewModel.routingMode.collectAsStateWithLifecycle()
+    val fullRouteCapture by viewModel.fullRouteCapture.collectAsStateWithLifecycle()
     val dnsResponseType by viewModel.dnsResponseType.collectAsStateWithLifecycle()
     val safeSearchEnabled by viewModel.safeSearchEnabled.collectAsStateWithLifecycle()
     val youtubeRestrictedMode by viewModel.youtubeRestrictedMode.collectAsStateWithLifecycle()
@@ -118,6 +119,7 @@ fun SettingsScreen(
                 routingMode = routingMode,
                 networkSwitchDelayEnabled = networkSwitchDelayEnabled,
                 networkSwitchDelaySec = networkSwitchDelaySec,
+                fullRouteCapture = fullRouteCapture,
                 safeSearchEnabled = safeSearchEnabled,
                 youtubeRestrictedMode = youtubeRestrictedMode,
                 dnsResponseType = dnsResponseType,
@@ -126,6 +128,7 @@ fun SettingsScreen(
                 onSetRoutingMode = { viewModel.setRoutingModeEnabled(it) },
                 onSetNetworkSwitchDelayEnabled = { viewModel.setNetworkSwitchDelayEnabled(it) },
                 onSetNetworkSwitchDelaySec = { viewModel.setNetworkSwitchDelaySec(it) },
+                onSetFullRouteCapture = { viewModel.setFullRouteCapture(it) },
                 onSetSafeSearchEnabled = { viewModel.setSafeSearchEnabled(it) },
                 onSetYoutubeRestrictedMode = { viewModel.setYoutubeRestrictedMode(it) },
                 onShowDnsResponseTypeDialog = { showDnsResponseTypeDialog = true },

--- a/app/src/main/java/app/pwhs/blockads/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/settings/SettingsViewModel.kt
@@ -126,6 +126,9 @@ class SettingsViewModel(
     val routingMode: StateFlow<String> = appPrefs.routingMode
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AppPreferences.ROUTING_MODE_DIRECT)
 
+    val fullRouteCapture: StateFlow<Boolean> = appPrefs.fullRouteCapture
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
     private val _events = MutableSharedFlow<UiEvent>(extraBufferCapacity = 1)
     val events: SharedFlow<UiEvent> = _events.asSharedFlow()
 
@@ -152,6 +155,14 @@ class SettingsViewModel(
 
     fun setNetworkSwitchDelayEnabled(enabled: Boolean) {
         viewModelScope.launch { appPrefs.setNetworkSwitchDelayEnabled(enabled) }
+    }
+
+    fun setFullRouteCapture(enabled: Boolean) {
+        viewModelScope.launch {
+            appPrefs.setFullRouteCapture(enabled)
+            // Re-establish the tunnel so the new routing takes effect now.
+            ServiceController.requestRestart(getApplication())
+        }
     }
 
     fun setNetworkSwitchDelaySec(seconds: Int) {

--- a/app/src/main/java/app/pwhs/blockads/ui/settings/component/ProtectionSection.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/settings/component/ProtectionSection.kt
@@ -34,6 +34,7 @@ import app.pwhs.blockads.R
 import app.pwhs.blockads.data.datastore.AppPreferences
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.filled.VpnKey
+import androidx.compose.material.icons.filled.VpnLock
 
 @Composable
 fun ProtectionSection(
@@ -41,6 +42,7 @@ fun ProtectionSection(
     routingMode: String,
     networkSwitchDelayEnabled: Boolean,
     networkSwitchDelaySec: Int,
+    fullRouteCapture: Boolean,
     safeSearchEnabled: Boolean,
     youtubeRestrictedMode: Boolean,
     dnsResponseType: String,
@@ -49,6 +51,7 @@ fun ProtectionSection(
     onSetRoutingMode: (Boolean) -> Unit,
     onSetNetworkSwitchDelayEnabled: (Boolean) -> Unit,
     onSetNetworkSwitchDelaySec: (Int) -> Unit,
+    onSetFullRouteCapture: (Boolean) -> Unit,
     onSetSafeSearchEnabled: (Boolean) -> Unit,
     onSetYoutubeRestrictedMode: (Boolean) -> Unit,
     onShowDnsResponseTypeDialog: () -> Unit,
@@ -129,6 +132,20 @@ fun ProtectionSection(
                             }
                         }
                     }
+                }
+                // Full network protection — only meaningful in Direct (DNS) mode
+                if (routingMode == AppPreferences.ROUTING_MODE_DIRECT) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        color = MaterialTheme.colorScheme.outline.copy(alpha = 0.1f)
+                    )
+                    SettingsToggleItem(
+                        icon = Icons.Default.VpnLock,
+                        title = stringResource(R.string.settings_full_route),
+                        subtitle = stringResource(R.string.settings_full_route_desc),
+                        isChecked = fullRouteCapture,
+                        onCheckedChange = onSetFullRouteCapture
+                    )
                 }
                 // Safe Search
                 HorizontalDivider(

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -527,4 +527,6 @@
     <string name="root_proxy_start_failed_text">تعذر الحصول على صلاحية الروت لبدء الحماية. انقر على تفعيل لإعادة المحاولة.</string>
     <string name="private_dns_warning_title">‏DNS الخاص مُفعّل</string>
     <string name="private_dns_warning_text">‏يتجاوز DNS الخاص في Android تطبيق BlockAds، لذا قد لا تُطبَّق التصفية. اضبط DNS الخاص على إيقاف أو تلقائي من إعدادات النظام.</string>
+    <string name="settings_full_route">حماية الشبكة الكاملة</string>
+    <string name="settings_full_route_desc">توجيه كل البيانات عبر BlockAds لمنع تسرّب DNS‏ (DNS الخاص/DoT). قد يؤثر على البطارية والسرعة. إذا انقطع الإنترنت فأوقفه.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">Nepodařilo se získat root oprávnění ke spuštění ochrany. Klepnutím na Povolit to zkuste znovu.</string>
     <string name="private_dns_warning_title">Soukromé DNS je zapnuté</string>
     <string name="private_dns_warning_text">Soukromé DNS systému Android obchází BlockAds, takže filtrování nemusí fungovat. Nastavte soukromé DNS na Vypnuto nebo Automaticky v nastavení systému.</string>
+    <string name="settings_full_route">Plná ochrana sítě</string>
+    <string name="settings_full_route_desc">Směrovat veškerý provoz přes BlockAds, aby se zabránilo únikům DNS (soukromé DNS/DoT). Může ovlivnit baterii a rychlost. Pokud ztratíte internet, vypněte to.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">Root-Zugriff zum Starten des Schutzes konnte nicht erlangt werden. Tippe auf Aktivieren, um es erneut zu versuchen.</string>
     <string name="private_dns_warning_title">Privates DNS ist aktiv</string>
     <string name="private_dns_warning_text">Android Privates DNS umgeht BlockAds, daher greift die Filterung evtl. nicht. Stelle Privates DNS in den Systemeinstellungen auf Aus oder Automatisch.</string>
+    <string name="settings_full_route">Vollständiger Netzwerkschutz</string>
+    <string name="settings_full_route_desc">Gesamten Datenverkehr über BlockAds leiten, um DNS-Lecks (Privates DNS/DoT) zu verhindern. Kann Akku und Geschwindigkeit beeinflussen. Bei Internetverlust ausschalten.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">No se pudo obtener acceso root para iniciar la protección. Toca Activar para reintentar.</string>
     <string name="private_dns_warning_title">DNS privado activado</string>
     <string name="private_dns_warning_text">El DNS privado de Android omite BlockAds, por lo que el filtrado puede no aplicarse. Configura el DNS privado como Desactivado o Automático en los ajustes del sistema.</string>
+    <string name="settings_full_route">Protección de red completa</string>
+    <string name="settings_full_route_desc">Enrutar todo el tráfico a través de BlockAds para evitar fugas de DNS (DNS privado/DoT). Puede afectar la batería y la velocidad. Si pierdes internet, desactívala.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">Impossible d\'obtenir l\'accès root pour démarrer la protection. Appuyez sur Activer pour réessayer.</string>
     <string name="private_dns_warning_title">DNS privé activé</string>
     <string name="private_dns_warning_text">Le DNS privé d\'Android contourne BlockAds, le filtrage peut donc ne pas s\'appliquer. Réglez le DNS privé sur Désactivé ou Automatique dans les paramètres système.</string>
+    <string name="settings_full_route">Protection réseau complète</string>
+    <string name="settings_full_route_desc">Acheminer tout le trafic via BlockAds pour empêcher les fuites DNS (DNS privé/DoT). Peut affecter la batterie et la vitesse. En cas de perte d\'internet, désactivez-la.</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">Tidak bisa mendapatkan akses root untuk memulai perlindungan. Ketuk Aktifkan untuk mencoba lagi.</string>
     <string name="private_dns_warning_title">DNS Pribadi aktif</string>
     <string name="private_dns_warning_text">DNS Pribadi Android melewati BlockAds, sehingga pemfilteran mungkin tidak diterapkan. Setel DNS Pribadi ke Nonaktif atau Otomatis di setelan sistem.</string>
+    <string name="settings_full_route">Perlindungan jaringan penuh</string>
+    <string name="settings_full_route_desc">Arahkan semua lalu lintas melalui BlockAds untuk mencegah kebocoran DNS (DNS Pribadi/DoT). Dapat memengaruhi baterai dan kecepatan. Jika internet putus, matikan.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">Impossibile ottenere l\'accesso root per avviare la protezione. Tocca Attiva per riprovare.</string>
     <string name="private_dns_warning_title">DNS privato attivo</string>
     <string name="private_dns_warning_text">Il DNS privato di Android aggira BlockAds, quindi il filtraggio potrebbe non essere applicato. Imposta il DNS privato su Disattivato o Automatico nelle impostazioni di sistema.</string>
+    <string name="settings_full_route">Protezione di rete completa</string>
+    <string name="settings_full_route_desc">Instrada tutto il traffico tramite BlockAds per impedire fughe di DNS (DNS privato/DoT). Può influire su batteria e velocità. Se perdi internet, disattivala.</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">לא ניתן לקבל גישת root כדי להפעיל את ההגנה. הקש על הפעלה כדי לנסות שוב.</string>
     <string name="private_dns_warning_title">‏DNS פרטי פעיל</string>
     <string name="private_dns_warning_text">‏DNS פרטי של Android עוקף את BlockAds, ולכן הסינון עלול לא לחול. הגדירו את ה-DNS הפרטי לכבוי או אוטומטי בהגדרות המערכת.</string>
+    <string name="settings_full_route">הגנת רשת מלאה</string>
+    <string name="settings_full_route_desc">ניתוב כל התעבורה דרך BlockAds כדי למנוע דליפות DNS‏ (DNS פרטי/DoT). עלול להשפיע על הסוללה והמהירות. אם אין אינטרנט, כבו זאת.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">保護を開始するための root 権限を取得できませんでした。「有効にする」をタップして再試行してください。</string>
     <string name="private_dns_warning_title">プライベート DNS が有効です</string>
     <string name="private_dns_warning_text">Android のプライベート DNS は BlockAds を迂回するため、フィルタリングが適用されないことがあります。システム設定でプライベート DNS をオフまたは自動に設定してください。</string>
+    <string name="settings_full_route">ネットワーク全体保護</string>
+    <string name="settings_full_route_desc">すべての通信を BlockAds 経由にして DNS 漏れ（プライベート DNS/DoT）を防ぎます。電池や速度に影響する場合があります。ネットに繋がらない場合はオフにしてください。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">보호를 시작하기 위한 루트 권한을 얻지 못했습니다. 다시 시도하려면 사용을 누르세요.</string>
     <string name="private_dns_warning_title">비공개 DNS가 켜져 있습니다</string>
     <string name="private_dns_warning_text">Android 비공개 DNS는 BlockAds를 우회하므로 필터링이 적용되지 않을 수 있습니다. 시스템 설정에서 비공개 DNS를 끄거나 자동으로 설정하세요.</string>
+    <string name="settings_full_route">전체 네트워크 보호</string>
+    <string name="settings_full_route_desc">모든 트래픽을 BlockAds로 라우팅하여 DNS 누출(비공개 DNS/DoT)을 차단합니다. 배터리와 속도에 영향을 줄 수 있습니다. 인터넷이 끊기면 끄세요.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">Nie udało się uzyskać dostępu root, aby uruchomić ochronę. Stuknij Włącz, aby spróbować ponownie.</string>
     <string name="private_dns_warning_title">Prywatny DNS jest włączony</string>
     <string name="private_dns_warning_text">Prywatny DNS systemu Android omija BlockAds, więc filtrowanie może nie działać. Ustaw prywatny DNS na Wyłączony lub Automatyczny w ustawieniach systemu.</string>
+    <string name="settings_full_route">Pełna ochrona sieci</string>
+    <string name="settings_full_route_desc">Kieruj cały ruch przez BlockAds, aby zapobiec wyciekom DNS (prywatny DNS/DoT). Może wpływać na baterię i szybkość. Jeśli stracisz internet, wyłącz to.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">Não foi possível obter acesso root para iniciar a proteção. Toque em Ativar para tentar novamente.</string>
     <string name="private_dns_warning_title">DNS privado está ativado</string>
     <string name="private_dns_warning_text">O DNS privado do Android ignora o BlockAds, então a filtragem pode não ser aplicada. Defina o DNS privado como Desativado ou Automático nas configurações do sistema.</string>
+    <string name="settings_full_route">Proteção total da rede</string>
+    <string name="settings_full_route_desc">Encaminhar todo o tráfego pelo BlockAds para impedir vazamentos de DNS (DNS privado/DoT). Pode afetar bateria e velocidade. Se ficar sem internet, desative.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">Не удалось получить root-доступ для запуска защиты. Нажмите «Включить», чтобы повторить попытку.</string>
     <string name="private_dns_warning_title">Частный DNS включён</string>
     <string name="private_dns_warning_text">Частный DNS Android обходит BlockAds, поэтому фильтрация может не работать. Установите «Частный DNS» в значение «Выкл.» или «Автоматически» в настройках системы.</string>
+    <string name="settings_full_route">Полная защита сети</string>
+    <string name="settings_full_route_desc">Направлять весь трафик через BlockAds, чтобы предотвратить утечки DNS (Частный DNS/DoT). Может влиять на батарею и скорость. Если пропал интернет — отключите.</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">ไม่สามารถรับสิทธิ์รูทเพื่อเริ่มการป้องกันได้ แตะ เปิดใช้งาน เพื่อลองอีกครั้ง</string>
     <string name="private_dns_warning_title">เปิด DNS ส่วนตัวอยู่</string>
     <string name="private_dns_warning_text">DNS ส่วนตัวของ Android จะข้าม BlockAds การกรองจึงอาจไม่ทำงาน โปรดตั้งค่า DNS ส่วนตัวเป็นปิดหรืออัตโนมัติในการตั้งค่าระบบ</string>
+    <string name="settings_full_route">ป้องกันเครือข่ายเต็มรูปแบบ</string>
+    <string name="settings_full_route_desc">กำหนดเส้นทางทราฟฟิกทั้งหมดผ่าน BlockAds เพื่อป้องกัน DNS รั่ว (DNS ส่วนตัว/DoT) อาจมีผลต่อแบตเตอรี่และความเร็ว หากเน็ตหลุดให้ปิด</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -532,4 +532,6 @@ Desteklenen formatlar:
     <string name="root_proxy_start_failed_text">Korumayı başlatmak için root erişimi alınamadı. Yeniden denemek için Etkinleştir\'e dokunun.</string>
     <string name="private_dns_warning_title">Özel DNS açık</string>
     <string name="private_dns_warning_text">Android Özel DNS, BlockAds\'i atlar; bu nedenle filtreleme uygulanmayabilir. Sistem ayarlarından Özel DNS\'i Kapalı veya Otomatik yapın.</string>
+    <string name="settings_full_route">Tam ağ koruması</string>
+    <string name="settings_full_route_desc">DNS sızıntılarını (Özel DNS/DoT) önlemek için tüm trafiği BlockAds üzerinden yönlendir. Pil ve hızı etkileyebilir. İnternet giderse bunu kapatın.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">Не вдалося отримати root-доступ для запуску захисту. Натисніть «Увімкнути», щоб повторити спробу.</string>
     <string name="private_dns_warning_title">Приватний DNS увімкнено</string>
     <string name="private_dns_warning_text">Приватний DNS Android обходить BlockAds, тож фільтрування може не застосовуватися. Установіть приватний DNS на «Вимкнено» або «Автоматично» в налаштуваннях системи.</string>
+    <string name="settings_full_route">Повний захист мережі</string>
+    <string name="settings_full_route_desc">Спрямовувати весь трафік через BlockAds, щоб запобігти витокам DNS (приватний DNS/DoT). Може впливати на батарею та швидкість. Якщо зник інтернет — вимкніть.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">Không thể lấy quyền root để bật bảo vệ. Nhấn Bật để thử lại.</string>
     <string name="private_dns_warning_title">DNS riêng tư đang bật</string>
     <string name="private_dns_warning_text">DNS riêng tư của Android bỏ qua BlockAds nên việc lọc có thể không áp dụng. Hãy đặt DNS riêng tư về Tắt hoặc Tự động trong cài đặt hệ thống.</string>
+    <string name="settings_full_route">Bảo vệ toàn mạng</string>
+    <string name="settings_full_route_desc">Định tuyến toàn bộ lưu lượng qua BlockAds để chặn rò rỉ DNS (DNS riêng tư/DoT). Có thể ảnh hưởng pin và tốc độ. Nếu mất mạng, hãy tắt tùy chọn này.</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -511,4 +511,6 @@
     <string name="root_proxy_start_failed_text">无法获取 Root 权限以启动防护。点按“启用”重试。</string>
     <string name="private_dns_warning_title">私人 DNS 已开启</string>
     <string name="private_dns_warning_text">Android 私人 DNS 会绕过 BlockAds，因此过滤可能不生效。请在系统设置中将私人 DNS 设为“关闭”或“自动”。</string>
+    <string name="settings_full_route">全网络保护</string>
+    <string name="settings_full_route_desc">通过 BlockAds 路由所有流量以防止 DNS 泄漏（私人 DNS/DoT）。可能影响电量和速度。若无法上网，请关闭。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -507,6 +507,8 @@
     <string name="root_proxy_start_failed_text">Could not get root access to start protection. Tap Enable to retry.</string>
     <string name="private_dns_warning_title">Private DNS is on</string>
     <string name="private_dns_warning_text">Android Private DNS bypasses BlockAds, so filtering may not apply. Set Private DNS to Off or Automatic in system settings.</string>
+    <string name="settings_full_route">Full network protection</string>
+    <string name="settings_full_route_desc">Route all traffic through BlockAds to stop DNS leaks (Private DNS/DoT). May affect battery and speed. If you lose internet, turn this off.</string>
     <string name="reddit_link" translatable="false">https://www.reddit.com/r/BlockAds/</string>
     <string name="telegram_link" translatable="false">https://t.me/blockads_android</string>
     <string name="test_block_link" translatable="false">https://adblock.turtlecute.org/</string>


### PR DESCRIPTION
## Why
Full-route (`0.0.0.0/0`) capture is what actually closes the Private DNS/DoT leak (#145) and enables kill-switch compatibility (#162). But forcing it on everyone (#187) **broke internet** — the engine drops non-DNS packets in DNS-only mode unless the userspace TCP stack is active. So instead of forcing or abandoning it, this makes it an **opt-in toggle, default OFF**.

## Behavior
- **OFF (default):** DNS-only routing (only fake DNS IPs captured) + `allowBypass()` — the proven safe default. No internet breakage for anyone.
- **ON:** `establishVpn()` routes `0.0.0.0/0` + `::/0` (with the existing LAN-exclude logic), drops `allowBypass()`, **and** `GoTunnelAdapter.start(forwardAllTraffic=true)` enables the userspace TCP stack so the engine **forwards** non-DNS flows via `DirectOutbound` on `protect()`ed sockets instead of dropping them. Toggling restarts the tunnel so it applies right away.

## Surfaces
- **Settings → Protection:** "Full network protection" switch (shown in Direct mode).
- **Home:** compact toggle (Direct mode only).
- New pref `fullRouteCapture` (default false). Strings translated to all 19 locales. Subtitle warns: *"If you lose internet, turn this off."*

WireGuard mode is unaffected (already full-tunnel); Root Proxy mode unaffected.

## Test
`:app:assembleDebug` + `:app:lintDebug` pass. **On-device:** default OFF → internet works (regression-safe). Turn ON → run dnsleaktest with Private DNS = Opportunistic; verify no ISP DNS, and that general browsing / IPv6 / video still work (this validates the engine forwards non-DNS with the TCP stack on). If any traffic breaks with it ON, that's the engine-forwarding limitation and the user simply leaves it OFF.

Relates to #145, #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Full network protection" toggle that routes all network traffic through the app in DNS-only mode
  * New toggles available in both home and settings screens with descriptions about battery and speed impact

* **Localization**
  * Added support for the full network protection feature across 18+ languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->