### PR TITLE
fix: full-route capture forwards traffic via DirectOutbound (#145)

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/service/GoTunnelAdapter.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/GoTunnelAdapter.kt
@@ -264,16 +264,20 @@ class GoTunnelAdapter(
 
         // Full-route capture (DNS-only mode toggle): the TUN now receives ALL
         // packets, so the engine must forward non-DNS flows instead of
-        // dropping them. Enable the userspace TCP stack (without MITM) so the
-        // engine terminates and forwards TCP via DirectOutbound on protect()ed
-        // sockets. Without this, routing 0.0.0.0/0 blackholes traffic (#187).
-        // When HTTPS filtering is on the stack is already enabled below.
+        // dropping them. Enabling the userspace TCP stack alone is NOT enough
+        // — the stack needs an OutboundAdapter to actually send packets out,
+        // otherwise everything is blackholed (observed: full-route = no
+        // internet). The HTTPS-filtering path gets its outbound from
+        // startStackMitm(); for plain full-route we wire a DirectOutbound
+        // adapter so flows are forwarded straight to the internet (no MITM).
+        // The engine's protector (passed to start()) protects these sockets.
         if (forwardAllTraffic && !httpsFilteringEnabled) {
             try {
                 engine.setUseTcpStack(true)
-                Timber.d("Full-route capture: userspace TCP stack enabled for forwarding")
+                engine.setOutboundAdapter(tunnel.DirectOutbound())
+                Timber.d("Full-route capture: TCP stack + DirectOutbound enabled for forwarding")
             } catch (e: Exception) {
-                Timber.e(e, "Failed to enable TCP stack for full-route capture")
+                Timber.e(e, "Failed to enable forwarding for full-route capture")
             }
         }
 


### PR DESCRIPTION
## Problem
With the Full network protection toggle ON, there was **no internet** — `setUseTcpStack(true)` was enabled but the userspace stack had no `OutboundAdapter`, so it dropped all flows instead of forwarding them. (Logs: stack enabled, VPN established, but no traffic.)

## Fix
Wire `engine.setOutboundAdapter(tunnel.DirectOutbound())` alongside `setUseTcpStack(true)` in the full-route (non-HTTPS) path. `DirectOutbound` forwards flows straight to the internet without MITM; the HTTPS path already gets its outbound via `startStackMitm()`. The engine's `SocketProtector` (passed to `start()`) protects these outbound sockets from looping.

Default OFF is unchanged (safe DNS-only). This only affects the ON path that was broken.

## Test
`:app:assembleDebug` passes. **Needs device re-test:** turn the toggle ON → internet should work AND dnsleaktest should show no ISP DNS. If it still breaks, full-route forwarding isn't achievable with this engine build and the toggle should be removed pending Go-engine work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved network traffic forwarding behavior for full-route DNS capture mode when HTTPS filtering is disabled, ensuring proper initialization of the TCP stack and traffic routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->