### PR TITLE
Stabilize root proxy routing state

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/MainActivity.kt
+++ b/app/src/main/java/app/pwhs/blockads/MainActivity.kt
@@ -23,6 +23,7 @@ import app.pwhs.blockads.utils.LocaleHelper
 import app.pwhs.blockads.service.AdBlockVpnService
 import app.pwhs.blockads.service.IptablesManager
 import app.pwhs.blockads.service.RootProxyService
+import app.pwhs.blockads.service.ServiceController
 import app.pwhs.blockads.ui.BlockAdsApp
 import app.pwhs.blockads.ui.theme.BlockadsTheme
 import kotlinx.coroutines.flow.first
@@ -159,17 +160,14 @@ class MainActivity : ComponentActivity() {
             val routingMode = runBlocking { appPrefs.routingMode.first() }
 
             if (routingMode == AppPreferences.ROUTING_MODE_ROOT) {
-                if (RootProxyService.isRunning) {
-                    RootProxyService.stop(this)
+                if (RootProxyService.isRunning || AdBlockVpnService.isRunning) {
+                    ServiceController.requestStop(this)
                 } else {
                     handleVpnToggle()
                 }
             } else {
-                if (AdBlockVpnService.isRunning) {
-                    val stopIntent = Intent(this, AdBlockVpnService::class.java).apply {
-                        action = AdBlockVpnService.ACTION_STOP
-                    }
-                    startService(stopIntent)
+                if (AdBlockVpnService.isRunning || RootProxyService.isRunning) {
+                    ServiceController.requestStop(this)
                 } else {
                     handleVpnToggle()
                 }
@@ -201,7 +199,7 @@ class MainActivity : ComponentActivity() {
             if (routingMode == AppPreferences.ROUTING_MODE_ROOT) {
                 if (IptablesManager.isRootAvailable()) {
                     withContext(Dispatchers.Main) {
-                        RootProxyService.start(this@MainActivity)
+                        ServiceController.requestStart(this@MainActivity)
                     }
                 } else {
                     // If root is lost, fallback to Direct mode and request VPN permission
@@ -229,13 +227,6 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun startVpnService() {
-        val intent = Intent(this, AdBlockVpnService::class.java).apply {
-            action = AdBlockVpnService.ACTION_START
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            startForegroundService(intent)
-        } else {
-            startService(intent)
-        }
+        ServiceController.requestStart(this)
     }
 }

--- a/app/src/main/java/app/pwhs/blockads/data/datastore/AppPreferences.kt
+++ b/app/src/main/java/app/pwhs/blockads/data/datastore/AppPreferences.kt
@@ -152,6 +152,14 @@ class AppPreferences(private val context: Context) {
         prefs[KEY_VPN_ENABLED] ?: false
     }
 
+    /**
+     * Whether the user wants BlockAds protection to stay enabled and be
+     * restored after boot/network changes. Backed by the legacy
+     * "vpn_enabled" key for compatibility; it no longer means that the
+     * Android VpnService itself is currently running.
+     */
+    val protectionDesired: Flow<Boolean> = vpnEnabled
+
     val autoReconnect: Flow<Boolean> = context.dataStore.data.map { prefs ->
         prefs[KEY_AUTO_RECONNECT] ?: true
     }
@@ -387,6 +395,10 @@ class AppPreferences(private val context: Context) {
         context.dataStore.edit { prefs ->
             prefs[KEY_VPN_ENABLED] = enabled
         }
+    }
+
+    suspend fun setProtectionDesired(enabled: Boolean) {
+        setVpnEnabled(enabled)
     }
 
     suspend fun setAutoReconnect(enabled: Boolean) {

--- a/app/src/main/java/app/pwhs/blockads/data/entities/ProfileManager.kt
+++ b/app/src/main/java/app/pwhs/blockads/data/entities/ProfileManager.kt
@@ -147,6 +147,43 @@ class ProfileManager(
         // Store active profile id in preferences
         appPrefs.setActiveProfileId(profileId)
 
+        applyProfileSettings(profile, reloadFilters = true)
+        Timber.d("Switched to profile: ${profile.name}")
+    }
+
+    /**
+     * Switch to the preset profile that matches the protection level selected
+     * during onboarding.
+     */
+    suspend fun switchToProtectionLevel(level: String) = withContext(Dispatchers.IO) {
+        seedPresetsIfNeeded()
+        filterRepo.seedDefaultsIfNeeded()
+
+        val profileType = when (level) {
+            AppPreferences.PROTECTION_STRICT,
+            ProtectionProfile.TYPE_STRICT -> ProtectionProfile.TYPE_STRICT
+            else -> ProtectionProfile.TYPE_DEFAULT
+        }
+        val profile = profileDao.getByType(profileType) ?: run {
+            Timber.w("No preset profile found for onboarding protection level: $level")
+            return@withContext
+        }
+        switchToProfile(profile.id)
+    }
+
+    /**
+     * Re-apply the active profile after filter-list syncs. This keeps freshly
+     * inserted remote filters from reverting the user to remote defaults.
+     */
+    suspend fun reapplyActiveProfile() = withContext(Dispatchers.IO) {
+        val profile = profileDao.getActive() ?: return@withContext
+        applyProfileSettings(profile, reloadFilters = false)
+    }
+
+    private suspend fun applyProfileSettings(
+        profile: ProtectionProfile,
+        reloadFilters: Boolean
+    ) {
         // Apply filter list configuration
         val profileUrls = profile.enabledFilterUrls
             .split(",")
@@ -167,9 +204,9 @@ class ProfileManager(
         appPrefs.setYoutubeRestrictedMode(profile.youtubeRestrictedMode)
 
         // Reload filters
-        filterRepo.loadAllEnabledFilters()
-
-        Timber.d("Switched to profile: ${profile.name}")
+        if (reloadFilters) {
+            filterRepo.loadAllEnabledFilters()
+        }
     }
 
     /**

--- a/app/src/main/java/app/pwhs/blockads/di/AppModule.kt
+++ b/app/src/main/java/app/pwhs/blockads/di/AppModule.kt
@@ -205,6 +205,7 @@ val appModule = module {
     viewModel {
         OnboardingViewModel(
             appPrefs = get(),
+            profileManager = get(),
             application = androidApplication()
         )
     }
@@ -257,4 +258,3 @@ val appModule = module {
         )
     }
 }
-

--- a/app/src/main/java/app/pwhs/blockads/service/AdBlockTileService.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/AdBlockTileService.kt
@@ -34,13 +34,13 @@ class AdBlockTileService : TileService() {
         val isVpnRunning = AdBlockVpnService.isRunning
 
         if (isRootProxyRunning) {
-            RootProxyService.stop(this)
+            ServiceController.requestStop(this)
         } else if (isVpnRunning) {
-            AdBlockVpnService.stop(this)
+            ServiceController.requestStop(this)
         } else {
             val routingMode = runBlocking { appPrefs.getRoutingModeSnapshot() }
             if (routingMode == AppPreferences.ROUTING_MODE_ROOT) {
-                RootProxyService.start(this)
+                ServiceController.requestStart(this)
             } else {
                 if (VpnUtils.isOtherVpnActive(this)) {
                     val intent = Intent(this, MainActivity::class.java).apply {
@@ -59,7 +59,7 @@ class AdBlockTileService : TileService() {
                     return
                 }
 
-                AdBlockVpnService.start(this)
+                ServiceController.requestStart(this)
             }
         }
 

--- a/app/src/main/java/app/pwhs/blockads/service/AdBlockVpnService.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/AdBlockVpnService.kt
@@ -13,6 +13,7 @@ import android.os.ParcelFileDescriptor
 import app.pwhs.blockads.MainActivity
 import app.pwhs.blockads.R
 import app.pwhs.blockads.data.datastore.AppPreferences
+import app.pwhs.blockads.data.entities.ProfileManager
 import app.pwhs.blockads.data.entities.WireGuardConfig
 import app.pwhs.blockads.data.repository.FilterListRepository
 import app.pwhs.blockads.data.dao.FirewallRuleDao
@@ -102,6 +103,7 @@ class AdBlockVpnService : VpnService() {
         const val ACTION_PAUSE_1H = "app.pwhs.blockads.PAUSE_VPN_1H"
         const val ACTION_RESTART = "app.pwhs.blockads.RESTART_VPN"
         const val EXTRA_STARTED_FROM_BOOT = "extra_started_from_boot"
+        const val EXTRA_MARK_PROTECTION_DISABLED = "extra_mark_protection_disabled"
 
         // When a VPN session is (re)established, Android revokes the
         // previous session and delivers onRevoke() to the (single) service
@@ -165,16 +167,18 @@ class AdBlockVpnService : VpnService() {
             }
         }
 
-        fun start(context: Context) {
+        fun start(context: Context, startedFromBoot: Boolean = false) {
             val intent = Intent(context, AdBlockVpnService::class.java).apply {
                 action = ACTION_START
+                putExtra(EXTRA_STARTED_FROM_BOOT, startedFromBoot)
             }
             androidx.core.content.ContextCompat.startForegroundService(context, intent)
         }
 
-        fun stop(context: Context) {
+        fun stop(context: Context, markProtectionDisabled: Boolean = true) {
             val intent = Intent(context, AdBlockVpnService::class.java).apply {
                 action = ACTION_STOP
+                putExtra(EXTRA_MARK_PROTECTION_DISABLED, markProtectionDisabled)
             }
             context.startService(intent)
         }
@@ -187,6 +191,7 @@ class AdBlockVpnService : VpnService() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private lateinit var filterRepo: FilterListRepository
     private lateinit var appPrefs: AppPreferences
+    private lateinit var profileManager: ProfileManager
     private lateinit var dnsLogDao: DnsLogDao
     private lateinit var goTunnelAdapter: GoTunnelAdapter
     private var networkMonitor: NetworkMonitor? = null
@@ -234,6 +239,7 @@ class AdBlockVpnService : VpnService() {
         val koin = org.koin.java.KoinJavaComponent.getKoin()
         filterRepo = koin.get()
         appPrefs = koin.get()
+        profileManager = koin.get()
         dnsLogDao = koin.get()
 
         serviceScope.launch {
@@ -291,7 +297,8 @@ class AdBlockVpnService : VpnService() {
 
         when (intent?.action) {
             ACTION_STOP -> {
-                stopVpn()
+                val markProtectionDisabled = intent.getBooleanExtra(EXTRA_MARK_PROTECTION_DISABLED, true)
+                stopVpn(markProtectionDisabled = markProtectionDisabled)
                 return START_NOT_STICKY
             }
 
@@ -301,14 +308,37 @@ class AdBlockVpnService : VpnService() {
             }
 
             ACTION_RESTART -> {
+                if (!isVpnRoutingAllowed()) {
+                    stopVpn(showStoppedNotification = false, markProtectionDisabled = false)
+                    return START_NOT_STICKY
+                }
+                stopRootProxyIfActive()
                 restartVpn()
                 return START_STICKY
             }
 
             else -> {
+                if (!isVpnRoutingAllowed()) {
+                    Timber.w("Ignoring VPN start while Root routing mode is selected")
+                    stopSelf()
+                    return START_NOT_STICKY
+                }
+                stopRootProxyIfActive()
                 startVpn(startedFromBoot)
                 return START_STICKY
             }
+        }
+    }
+
+    private fun isVpnRoutingAllowed(): Boolean {
+        return runBlocking {
+            appPrefs.getRoutingModeSnapshot() != AppPreferences.ROUTING_MODE_ROOT
+        }
+    }
+
+    private fun stopRootProxyIfActive() {
+        if (RootProxyService.state.value != VpnState.STOPPED) {
+            RootProxyService.stop(this, markProtectionDisabled = false)
         }
     }
 
@@ -378,6 +408,7 @@ class AdBlockVpnService : VpnService() {
 
                 filterRepo.seedDefaultsIfNeeded()
                 filterRepo.fetchAndSyncRemoteFilterLists()
+                profileManager.reapplyActiveProfile()
                 val result = filterRepo.loadAllEnabledFilters()
                 Timber.d("Filters loaded: ${result.getOrDefault(0)} domains")
 
@@ -451,7 +482,7 @@ class AdBlockVpnService : VpnService() {
                     Timber
                         .e("Failed to establish VPN after ${retryManager.getMaxRetries()} attempts")
                     connectingPhase = ""
-                    stopVpn()
+                    stopVpn(markProtectionDisabled = false)
                     return@launch
                 }
 
@@ -465,7 +496,7 @@ class AdBlockVpnService : VpnService() {
                 val resumedFromReconnect = isReconnecting && vpnStartTime > 0L
                 isReconnecting = false
                 _state.value = VpnState.RUNNING
-                appPrefs.setVpnEnabled(true)
+                appPrefs.setProtectionDesired(true)
                 // Initial Private DNS check (callback only fires on change)
                 runCatching {
                     val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -576,7 +607,7 @@ class AdBlockVpnService : VpnService() {
 
             } catch (e: Exception) {
                 Timber.e(e, "VPN startup failed")
-                stopVpn()
+                stopVpn(markProtectionDisabled = false)
             }
         }
     }
@@ -834,7 +865,7 @@ class AdBlockVpnService : VpnService() {
         )
 
         // Stop VPN but show paused notification
-        stopVpn(showStoppedNotification = false)
+        stopVpn(showStoppedNotification = false, markProtectionDisabled = false)
         showPausedNotification()
     }
 
@@ -888,11 +919,18 @@ class AdBlockVpnService : VpnService() {
         notificationManager.notify(NOTIFICATION_ID, notification)
     }
 
-    private fun stopVpn(showStoppedNotification: Boolean = true) {
+    private fun stopVpn(
+        showStoppedNotification: Boolean = true,
+        markProtectionDisabled: Boolean = true,
+    ) {
         _state.value = VpnState.STOPPING
         isReconnecting = false
         networkSwitchJob?.cancel()
         startTimestamp = 0L
+
+        if (markProtectionDisabled) {
+            ServiceController.cancelResumeWork(this)
+        }
 
         // Show "Stopping…" notification immediately
         updateNotification()
@@ -907,8 +945,10 @@ class AdBlockVpnService : VpnService() {
             // Stop Go tunnel engine (this is the heavy native call that was causing ANR)
             goTunnelAdapter.stop()
 
-            runBlocking {
-                appPrefs.setVpnEnabled(false)
+            if (markProtectionDisabled) {
+                runBlocking {
+                    appPrefs.setProtectionDesired(false)
+                }
             }
 
             try {
@@ -956,10 +996,10 @@ class AdBlockVpnService : VpnService() {
         // Update preferences to reflect VPN is no longer enabled
         // Use a non-cancellable context to ensure preference is updated
         serviceScope.launch(NonCancellable) {
-            appPrefs.setVpnEnabled(false)
+            appPrefs.setProtectionDesired(false)
         }
         showRevokedNotification()
-        stopVpn(showStoppedNotification = false)
+        stopVpn(showStoppedNotification = false, markProtectionDisabled = true)
         super.onRevoke()
     }
 
@@ -1194,7 +1234,7 @@ class AdBlockVpnService : VpnService() {
 
         networkSwitchJob = serviceScope.launch {
             val autoReconnect = appPrefs.autoReconnect.first()
-            val vpnWasEnabled = appPrefs.vpnEnabled.first()
+            val protectionDesired = appPrefs.protectionDesired.first()
             val delayEnabled = appPrefs.networkSwitchDelayEnabled.first()
             val delaySec = appPrefs.networkSwitchDelaySec.first()
 
@@ -1232,7 +1272,7 @@ class AdBlockVpnService : VpnService() {
             }
 
             // Case 2: VPN is not running but should be → reconnect
-            if (autoReconnect && vpnWasEnabled && !isRunning && !isConnecting && !isRestarting && !isStopping) {
+            if (autoReconnect && protectionDesired && !isRunning && !isConnecting && !isRestarting && !isStopping) {
                 Timber.d("Auto-reconnecting VPN after network became available")
                 isReconnecting = true
 
@@ -1255,7 +1295,11 @@ class AdBlockVpnService : VpnService() {
 
                 if (!isRunning && !isConnecting && !isStopping) {
                     retryManager.reset()
-                    startVpn()
+                    if (appPrefs.routingMode.first() == AppPreferences.ROUTING_MODE_ROOT) {
+                        ServiceController.requestStart(this@AdBlockVpnService)
+                    } else {
+                        startVpn()
+                    }
                 }
                 isReconnecting = false
             }

--- a/app/src/main/java/app/pwhs/blockads/service/BootReceiver.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/BootReceiver.kt
@@ -3,7 +3,6 @@ package app.pwhs.blockads.service
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import app.pwhs.blockads.data.datastore.AppPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -24,37 +23,13 @@ class BootReceiver : BroadcastReceiver() {
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
             try {
                 val autoReconnect = prefs.autoReconnect.first()
-                val wasEnabled = prefs.vpnEnabled.first()
+                val protectionDesired = prefs.protectionDesired.first()
                 val routingMode = prefs.routingMode.first()
 
-                // Root Mode: iptables rules are volatile (cleared on reboot).
-                // Re-apply rules by starting RootProxyService.
-                // Also restarts after app update (MY_PACKAGE_REPLACED).
-                if (autoReconnect && wasEnabled) {
+                if (autoReconnect && protectionDesired) {
                     val trigger = if (intent.action == Intent.ACTION_MY_PACKAGE_REPLACED) "app update" else "boot"
-                    if (routingMode == AppPreferences.ROUTING_MODE_ROOT) {
-                        Timber.d("Auto-starting Root Proxy mode after $trigger")
-                        val serviceIntent = Intent(context, RootProxyService::class.java).apply {
-                            action = RootProxyService.ACTION_START
-                            putExtra(RootProxyService.EXTRA_STARTED_FROM_BOOT, true)
-                        }
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                            context.startForegroundService(serviceIntent)
-                        } else {
-                            context.startService(serviceIntent)
-                        }
-                    } else {
-                        Timber.d("Auto-reconnecting VPN after $trigger")
-                        val serviceIntent = Intent(context, AdBlockVpnService::class.java).apply {
-                            action = AdBlockVpnService.ACTION_START
-                            putExtra(AdBlockVpnService.EXTRA_STARTED_FROM_BOOT, true)
-                        }
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                            context.startForegroundService(serviceIntent)
-                        } else {
-                            context.startService(serviceIntent)
-                        }
-                    }
+                    Timber.d("Auto-starting protection after $trigger, routingMode=$routingMode")
+                    ServiceController.requestStartNow(context, startedFromBoot = true)
                 }
             } catch (e: Exception) {
                 Timber.e(e, "Error starting service after boot")

--- a/app/src/main/java/app/pwhs/blockads/service/GoTunnelAdapter.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/GoTunnelAdapter.kt
@@ -10,18 +10,22 @@ import app.pwhs.blockads.data.repository.FilterListRepository
 import app.pwhs.blockads.utils.AppNameResolver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import tunnel.AppResolver
 import tunnel.DomainChecker
 import tunnel.FirewallChecker
 import tunnel.SocketProtector
 import tunnel.UIDResolver
+import java.io.ByteArrayOutputStream
+import java.net.DatagramPacket
+import java.net.DatagramSocket
 import java.net.InetAddress
 import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Bridge between Android VpnService and the Go DNS tunnel engine.
@@ -54,6 +58,8 @@ class GoTunnelAdapter(
 
     @Volatile
     private var isRunning = false
+
+    private val lastDnsActivityMillis = AtomicLong(0L)
 
     /**
      * Configure the DNS settings for the Go engine.
@@ -227,6 +233,7 @@ class GoTunnelAdapter(
      */
     private fun setupLogCallback() {
         engine.setLogCallback { domain, blocked, queryType, responseTimeMs, packageNameOrAppName, resolvedIP, blockedBy ->
+            lastDnsActivityMillis.set(System.currentTimeMillis())
             if (!recordLogProvider()) return@setLogCallback
 
             scope.launch(Dispatchers.IO) {
@@ -385,36 +392,25 @@ class GoTunnelAdapter(
         updateCosmeticRules()
 
         Timber.d("Starting Go tunnel engine in STANDALONE mode on port $port")
-        val deferred = kotlinx.coroutines.CompletableDeferred<Boolean>()
+        val startFailure = AtomicReference<Throwable?>(null)
 
         scope.launch(Dispatchers.IO) {
             try {
-                launch {
-                    delay(500)
-                    if (!deferred.isCompleted) {
-                        isRunning = true
-                        deferred.complete(true)
-                    }
-                }
                 engine.startStandalone(port.toLong())
             } catch (e: Exception) {
                 Timber.e(e, "Go standalone engine crashed or failed to start")
                 isRunning = false
-                if (!deferred.isCompleted) {
-                    deferred.complete(false)
-                }
+                startFailure.compareAndSet(null, e)
             }
         }
 
-        return try {
-            withTimeout(2000) {
-                deferred.await()
-            }
-        } catch (e: TimeoutCancellationException) {
-            Timber.e("Timeout waiting for Go engine to start")
-            isRunning = false
-            false
+        val ready = waitForStandaloneReady(port, startFailure)
+        isRunning = ready
+        if (!ready) {
+            Timber.e("Go standalone engine did not answer readiness probe")
+            engine.stop()
         }
+        return ready
     }
 
     /**
@@ -424,6 +420,15 @@ class GoTunnelAdapter(
         isRunning = false
         engine.stop()
         Timber.d("Go tunnel engine stopped")
+    }
+
+    fun isEngineRunning(): Boolean = isRunning
+
+    fun lastDnsActivityMillis(): Long = lastDnsActivityMillis.get()
+
+    suspend fun isStandaloneHealthy(port: Int = 15353): Boolean {
+        if (!isRunning) return false
+        return probeStandaloneDns(port)
     }
 
     /**
@@ -486,6 +491,9 @@ class GoTunnelAdapter(
     }
 
     companion object {
+        private const val HEALTH_DOMAIN = "local.pwhs.app"
+        private const val HEALTH_QUERY_ID = 0xB1AD
+
         /**
          * Convert DNS query type number to human-readable string.
          * DNS types defined in RFC 1035 & 3596.
@@ -496,5 +504,78 @@ class GoTunnelAdapter(
             5 -> "CNAME"
             else -> "OTHER"
         }
+    }
+
+    private suspend fun waitForStandaloneReady(
+        port: Int,
+        startFailure: AtomicReference<Throwable?>,
+    ): Boolean {
+        val deadline = System.currentTimeMillis() + 2_500L
+        while (System.currentTimeMillis() < deadline) {
+            if (startFailure.get() != null) return false
+            if (probeStandaloneDns(port)) return true
+            delay(100L)
+        }
+        return false
+    }
+
+    private suspend fun probeStandaloneDns(port: Int): Boolean = withContext(Dispatchers.IO) {
+        val query = buildHealthQuery()
+        val socket = DatagramSocket()
+        try {
+            socket.soTimeout = 700
+            socket.send(
+                DatagramPacket(
+                    query,
+                    query.size,
+                    InetAddress.getByName("127.0.0.1"),
+                    port
+                )
+            )
+            val response = ByteArray(512)
+            val packet = DatagramPacket(response, response.size)
+            socket.receive(packet)
+            isValidHealthResponse(response, packet.length)
+        } catch (e: Exception) {
+            false
+        } finally {
+            socket.close()
+        }
+    }
+
+    private fun buildHealthQuery(): ByteArray {
+        val out = ByteArrayOutputStream()
+        out.write((HEALTH_QUERY_ID shr 8) and 0xff)
+        out.write(HEALTH_QUERY_ID and 0xff)
+        out.write(0x01)
+        out.write(0x00)
+        out.write(0x00)
+        out.write(0x01)
+        out.write(0x00)
+        out.write(0x00)
+        out.write(0x00)
+        out.write(0x00)
+        out.write(0x00)
+        out.write(0x00)
+        HEALTH_DOMAIN.split('.').forEach { label ->
+            out.write(label.length)
+            out.write(label.toByteArray(Charsets.US_ASCII))
+        }
+        out.write(0x00)
+        out.write(0x00)
+        out.write(0x01)
+        out.write(0x00)
+        out.write(0x01)
+        return out.toByteArray()
+    }
+
+    private fun isValidHealthResponse(response: ByteArray, length: Int): Boolean {
+        if (length < 12) return false
+        val id = ((response[0].toInt() and 0xff) shl 8) or (response[1].toInt() and 0xff)
+        if (id != HEALTH_QUERY_ID) return false
+        val flags = ((response[2].toInt() and 0xff) shl 8) or (response[3].toInt() and 0xff)
+        val isResponse = flags and 0x8000 != 0
+        val rcode = flags and 0x000f
+        return isResponse && rcode == 0
     }
 }

--- a/app/src/main/java/app/pwhs/blockads/service/IptablesManager.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/IptablesManager.kt
@@ -21,7 +21,31 @@ object IptablesManager {
 
     private const val CHAIN = "BLOCKADS_DNS"
     private const val CHAIN_FILTER = "BLOCKADS_DOT"
+    // Kept only so teardown removes the old fallback chain from previous
+    // debug builds. Do not create this chain: rejecting IPv6 DNS can break
+    // connectivity on IPv6-first networks instead of causing IPv4 fallback.
+    private const val CHAIN_IPV6_DNS_FALLBACK = "BLOCKADS_DNS6_BLOCK"
     private const val LOCAL_DNS_PORT = 15353
+
+    data class SetupResult(
+        val ipv4Active: Boolean,
+        val ipv6Active: Boolean,
+    ) {
+        val usable: Boolean get() = ipv4Active
+    }
+
+    data class RuleStatus(
+        val ipv4Active: Boolean,
+        val ipv6Active: Boolean,
+    )
+
+    private data class PrivateDnsSnapshot(
+        val mode: String?,
+        val specifier: String?,
+    )
+
+    @Volatile
+    private var previousPrivateDns: PrivateDnsSnapshot? = null
 
     /**
      * Ensure the cached libsu main shell actually has root.
@@ -75,17 +99,29 @@ object IptablesManager {
         blockDoT: Boolean = true,
         whitelistUids: Collection<Int> = emptyList()
     ): Boolean {
+        return setupRulesDetailed(context, blockDoT, whitelistUids).usable
+    }
+
+    @Synchronized
+    fun setupRulesDetailed(
+        context: Context,
+        blockDoT: Boolean = true,
+        whitelistUids: Collection<Int> = emptyList()
+    ): SetupResult {
         val uid = context.applicationInfo.uid
         Timber.d("Setting up iptables rules for UID=$uid, blockDoT=$blockDoT, whitelistUids=$whitelistUids")
 
-        // Always teardown first (idempotent)
-        teardownRules()
+        // Always teardown first (idempotent), but do not restore Private DNS
+        // during internal setup/reload. The original value is restored only
+        // when Root mode really stops.
+        teardownRules(restorePrivateDns = false)
 
         // ══════════════════════════════════════════════════════════════
         // Step 0: Disable Android Private DNS so system uses port 53
         // This is CRITICAL — without this, Android 9+ uses DoT (853)
         // and our port 53 redirect never sees traffic.
         // ══════════════════════════════════════════════════════════════
+        savePrivateDnsIfNeeded()
         Shell.cmd("settings put global private_dns_mode off").exec()
         Timber.d("Disabled Android Private DNS (forced plain DNS mode)")
 
@@ -140,9 +176,12 @@ object IptablesManager {
         }
 
         // ══════════════════════════════════════════════════════════════
-        // IPv6 — try independently, many Android kernels lack ip6tables nat
+        // IPv6 — try NAT independently. Many Android kernels/ROMs lack
+        // ip6tables nat. If NAT is unavailable, report partial protection
+        // rather than blocking IPv6 DNS. Rejecting IPv6 DNS can break
+        // connectivity on IPv6-first networks instead of causing fallback.
         // ══════════════════════════════════════════════════════════════
-        val ipv6Commands = buildList {
+        val ipv6NatCommands = buildList {
             add("ip6tables -t nat -N $CHAIN 2>/dev/null || true")
             add("ip6tables -t nat -A $CHAIN -m owner --uid-owner $uid -j RETURN")
             for (wUid in whitelistUids) {
@@ -151,7 +190,18 @@ object IptablesManager {
             add("ip6tables -t nat -A $CHAIN -p udp --dport 53 -j REDIRECT --to-ports $LOCAL_DNS_PORT")
             add("ip6tables -t nat -A $CHAIN -p tcp --dport 53 -j REDIRECT --to-ports $LOCAL_DNS_PORT")
             add("ip6tables -t nat -A OUTPUT -j $CHAIN")
+        }
 
+        var ipv6NatSuccess = true
+        for (cmd in ipv6NatCommands) {
+            val result = Shell.cmd(cmd).exec()
+            if (!result.isSuccess) {
+                Timber.w("IPv6 ip6tables NAT cmd FAILED (will use fallback if needed): [$cmd] err=${result.err}")
+                ipv6NatSuccess = false
+            }
+        }
+
+        val ipv6FilterCommands = buildList {
             if (blockDoT) {
                 add("ip6tables -t filter -N $CHAIN_FILTER 2>/dev/null || true")
                 add("ip6tables -t filter -A $CHAIN_FILTER -m owner --uid-owner $uid -j RETURN")
@@ -163,29 +213,39 @@ object IptablesManager {
             }
         }
 
-        for (cmd in ipv6Commands) {
+        for (cmd in ipv6FilterCommands) {
             val result = Shell.cmd(cmd).exec()
             if (!result.isSuccess) {
-                Timber.w("IPv6 ip6tables cmd FAILED (ignoring): [$cmd] err=${result.err}")
+                Timber.w("IPv6 ip6tables filter cmd FAILED (ignoring): [$cmd] err=${result.err}")
             }
         }
 
+        val status = getStatus()
+
         // Verify rules are actually in place
-        val verified = isActive()
-        if (verified) {
+        if (status.ipv4Active) {
             Timber.d("iptables rules verified active")
         } else {
             Timber.e("iptables rules NOT active after setup — root may have been denied")
         }
+        if (status.ipv6Active) {
+            Timber.d("IPv6 DNS path is protected")
+        } else {
+            Timber.w("IPv6 DNS path is not protected; Root protection is IPv4-only")
+        }
 
-        return ipv4Success && verified
+        return SetupResult(
+            ipv4Active = ipv4Success && status.ipv4Active,
+            ipv6Active = ipv6NatSuccess && status.ipv6Active,
+        )
     }
 
     /**
      * Remove all BlockAds iptables rules and restore Private DNS.
      * Safe to call multiple times. Uses 2>/dev/null to suppress errors.
      */
-    fun teardownRules(): Boolean {
+    @Synchronized
+    fun teardownRules(restorePrivateDns: Boolean = true): Boolean {
         val commands = listOf(
             // IPv4 nat chain
             "iptables -t nat -D OUTPUT -j $CHAIN 2>/dev/null",
@@ -203,12 +263,17 @@ object IptablesManager {
             "ip6tables -t filter -D OUTPUT -j $CHAIN_FILTER 2>/dev/null",
             "ip6tables -t filter -F $CHAIN_FILTER 2>/dev/null",
             "ip6tables -t filter -X $CHAIN_FILTER 2>/dev/null",
-            // Restore Android Private DNS to automatic mode
-            "settings put global private_dns_mode opportunistic",
+            // IPv6 DNS fallback block chain
+            "ip6tables -t filter -D OUTPUT -j $CHAIN_IPV6_DNS_FALLBACK 2>/dev/null",
+            "ip6tables -t filter -F $CHAIN_IPV6_DNS_FALLBACK 2>/dev/null",
+            "ip6tables -t filter -X $CHAIN_IPV6_DNS_FALLBACK 2>/dev/null",
         )
 
         Shell.cmd(*commands.toTypedArray()).exec()
-        Timber.d("iptables teardown done, Private DNS restored")
+        if (restorePrivateDns) {
+            restorePrivateDns()
+        }
+        Timber.d("iptables teardown done, restorePrivateDns=$restorePrivateDns")
         return true
     }
 
@@ -220,5 +285,53 @@ object IptablesManager {
             "iptables -t nat -L OUTPUT -n 2>/dev/null | grep $CHAIN"
         ).exec()
         return result.out.any { it.contains(CHAIN) }
+    }
+
+    fun isIpv6Active(): Boolean {
+        val result = Shell.cmd(
+            "ip6tables -t nat -L OUTPUT -n 2>/dev/null | grep $CHAIN"
+        ).exec()
+        return result.out.any { it.contains(CHAIN) }
+    }
+
+    fun getStatus(): RuleStatus = RuleStatus(
+        ipv4Active = isActive(),
+        ipv6Active = isIpv6Active(),
+    )
+
+    private fun savePrivateDnsIfNeeded() {
+        if (previousPrivateDns != null) return
+        val mode = readGlobalSetting("private_dns_mode")
+        val specifier = readGlobalSetting("private_dns_specifier")
+        previousPrivateDns = PrivateDnsSnapshot(mode = mode, specifier = specifier)
+        Timber.d("Saved Private DNS state: mode=$mode, specifier=$specifier")
+    }
+
+    private fun restorePrivateDns() {
+        val snapshot = previousPrivateDns ?: return
+        if (snapshot.mode.isNullOrBlank()) {
+            Shell.cmd("settings delete global private_dns_mode").exec()
+        } else {
+            Shell.cmd("settings put global private_dns_mode ${shellQuote(snapshot.mode)}").exec()
+        }
+
+        if (snapshot.specifier.isNullOrBlank()) {
+            Shell.cmd("settings delete global private_dns_specifier").exec()
+        } else {
+            Shell.cmd("settings put global private_dns_specifier ${shellQuote(snapshot.specifier)}").exec()
+        }
+
+        previousPrivateDns = null
+        Timber.d("Restored Private DNS state")
+    }
+
+    private fun readGlobalSetting(name: String): String? {
+        val result = Shell.cmd("settings get global $name").exec()
+        val value = result.out.firstOrNull()?.trim()
+        return value?.takeUnless { it.isEmpty() || it == "null" }
+    }
+
+    private fun shellQuote(value: String): String {
+        return "'" + value.replace("'", "'\\''") + "'"
     }
 }

--- a/app/src/main/java/app/pwhs/blockads/service/ProtectionState.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/ProtectionState.kt
@@ -1,0 +1,81 @@
+package app.pwhs.blockads.service
+
+import app.pwhs.blockads.data.datastore.AppPreferences
+
+enum class ActualProtectionMode {
+    NONE,
+    VPN,
+    ROOT,
+    WIREGUARD,
+    CONFLICT,
+}
+
+sealed interface ActualProtectionState {
+    data object Stopped : ActualProtectionState
+    data object StartingVpn : ActualProtectionState
+    data object RunningVpn : ActualProtectionState
+    data object StartingRoot : ActualProtectionState
+    data object RunningRoot : ActualProtectionState
+    data object RunningWireGuard : ActualProtectionState
+    data object InconsistentBothRunning : ActualProtectionState
+    data object InconsistentWrongMode : ActualProtectionState
+    data class Failed(val reason: String) : ActualProtectionState
+}
+
+enum class ProtectionProblem {
+    BOTH_SERVICES_RUNNING,
+    WRONG_MODE_RUNNING,
+    ROOT_ENGINE_UNHEALTHY,
+    ROOT_ROUTING_INACTIVE,
+}
+
+data class RootProxyHealth(
+    val engineReady: Boolean = false,
+    val routingActive: Boolean = false,
+    val ipv6RoutingActive: Boolean = false,
+    val lastDnsActivity: Long? = null,
+)
+
+data class ProtectionHealth(
+    val serviceRunning: Boolean,
+    val engineReady: Boolean,
+    val routingActive: Boolean,
+    val ipv6RoutingActive: Boolean,
+    val lastDnsActivity: Long?,
+    val actualMode: ActualProtectionMode,
+    val desiredMode: String,
+    val state: ActualProtectionState,
+) {
+    val problem: ProtectionProblem?
+        get() = when (state) {
+            ActualProtectionState.InconsistentBothRunning -> ProtectionProblem.BOTH_SERVICES_RUNNING
+            ActualProtectionState.InconsistentWrongMode -> ProtectionProblem.WRONG_MODE_RUNNING
+            is ActualProtectionState.Failed -> when (state.reason) {
+                ServiceController.FAIL_REASON_ROOT_ENGINE -> ProtectionProblem.ROOT_ENGINE_UNHEALTHY
+                ServiceController.FAIL_REASON_ROOT_ROUTING -> ProtectionProblem.ROOT_ROUTING_INACTIVE
+                else -> ProtectionProblem.ROOT_ENGINE_UNHEALTHY
+            }
+            else -> null
+        }
+
+    val partialIpv6: Boolean
+        get() = actualMode == ActualProtectionMode.ROOT && routingActive && !ipv6RoutingActive
+}
+
+fun ActualProtectionState.isServiceActive(): Boolean = when (this) {
+    ActualProtectionState.RunningVpn,
+    ActualProtectionState.RunningRoot,
+    ActualProtectionState.RunningWireGuard,
+    ActualProtectionState.InconsistentBothRunning,
+    ActualProtectionState.InconsistentWrongMode,
+    is ActualProtectionState.Failed -> true
+    else -> false
+}
+
+fun ActualProtectionState.isStartingOrRestarting(): Boolean = when (this) {
+    ActualProtectionState.StartingVpn,
+    ActualProtectionState.StartingRoot -> true
+    else -> false
+}
+
+fun String.isRootRoutingMode(): Boolean = this == AppPreferences.ROUTING_MODE_ROOT

--- a/app/src/main/java/app/pwhs/blockads/service/RootProxyService.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/RootProxyService.kt
@@ -15,6 +15,7 @@ import app.pwhs.blockads.R
 import kotlinx.coroutines.flow.asStateFlow
 import app.pwhs.blockads.data.datastore.AppPreferences
 import kotlinx.coroutines.flow.first
+import app.pwhs.blockads.data.entities.ProfileManager
 import app.pwhs.blockads.data.repository.FilterListRepository
 import app.pwhs.blockads.data.dao.DnsLogDao
 import app.pwhs.blockads.data.dao.FirewallRuleDao
@@ -28,8 +29,11 @@ import app.pwhs.blockads.utils.startOfDayMillis
 import app.pwhs.blockads.worker.RootProxyResumeWorker
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.koin.java.KoinJavaComponent.getKoin
 import timber.log.Timber
 
@@ -42,7 +46,8 @@ import timber.log.Timber
  * - onCreate: Initialize Go engine + Koin dependencies
  * - onStartCommand(ACTION_START): Apply iptables rules + start watchdog
  * - onStartCommand(ACTION_STOP): Teardown iptables + stop engine
- * - onDestroy / onTaskRemoved: Teardown iptables (failsafe)
+ * - onDestroy: Teardown iptables (failsafe)
+ * - onTaskRemoved: Keep the foreground protection active
  */
 class RootProxyService : Service() {
 
@@ -53,21 +58,30 @@ class RootProxyService : Service() {
         const val ACTION_START = "app.pwhs.blockads.ROOT_START"
         const val ACTION_STOP = "app.pwhs.blockads.ROOT_STOP"
         const val ACTION_RESTART = "app.pwhs.blockads.ROOT_RESTART"
+        const val ACTION_RELOAD = "app.pwhs.blockads.ROOT_RELOAD"
         const val ACTION_PAUSE_1H = "app.pwhs.blockads.ROOT_PAUSE_1H"
         const val EXTRA_STARTED_FROM_BOOT = "extra_started_from_boot"
+        const val EXTRA_MARK_PROTECTION_DISABLED = "extra_mark_protection_disabled"
 
         private val _state = kotlinx.coroutines.flow.MutableStateFlow(VpnState.STOPPED)
         val state: kotlinx.coroutines.flow.StateFlow<VpnState> = _state.asStateFlow()
 
+        private val _health = kotlinx.coroutines.flow.MutableStateFlow(RootProxyHealth())
+        val health: kotlinx.coroutines.flow.StateFlow<RootProxyHealth> = _health.asStateFlow()
+
         val isRunning: Boolean get() = _state.value == VpnState.RUNNING
+        val isConnecting: Boolean get() = _state.value == VpnState.STARTING
+        val isRestarting: Boolean get() = _state.value == VpnState.RESTARTING
+        val isStopping: Boolean get() = _state.value == VpnState.STOPPING
 
         @Volatile
         var startTimestamp: Long = 0L
             private set
 
-        fun start(context: Context) {
+        fun start(context: Context, startedFromBoot: Boolean = false) {
             val intent = Intent(context, RootProxyService::class.java).apply {
                 action = ACTION_START
+                putExtra(EXTRA_STARTED_FROM_BOOT, startedFromBoot)
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 context.startForegroundService(intent)
@@ -76,22 +90,27 @@ class RootProxyService : Service() {
             }
         }
 
-        fun stop(context: Context) {
+        fun stop(context: Context, markProtectionDisabled: Boolean = true) {
             val intent = Intent(context, RootProxyService::class.java).apply {
                 action = ACTION_STOP
+                putExtra(EXTRA_MARK_PROTECTION_DISABLED, markProtectionDisabled)
             }
             context.startService(intent)
         }
 
         /**
-         * Request a Root Proxy restart to apply new settings/filter changes.
-         * Only restarts if the service is currently running.
+         * Backward-compatible name for callers that still ask for a restart.
+         * Runtime changes are applied with a reload to avoid tearing down
+         * working protection unnecessarily.
          */
         fun requestRestart(context: Context) {
-            val s = _state.value
-            if (s == VpnState.RUNNING || s == VpnState.RESTARTING) {
+            requestReload(context)
+        }
+
+        fun requestReload(context: Context) {
+            if (_state.value == VpnState.RUNNING) {
                 val intent = Intent(context, RootProxyService::class.java).apply {
-                    action = ACTION_RESTART
+                    action = ACTION_RELOAD
                 }
                 context.startService(intent)
             }
@@ -101,12 +120,14 @@ class RootProxyService : Service() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var watchdogJob: Job? = null
     private var notificationUpdateJob: Job? = null
+    private var filterUpdateJob: Job? = null
     private var retryManager = VpnRetryManager(maxRetries = 10, maxDelayMs = 60000L)
 
     @Volatile
     private var todayBlockedCount: Int = 0
     private lateinit var appPrefs: AppPreferences
     private lateinit var filterRepo: FilterListRepository
+    private lateinit var profileManager: ProfileManager
     private lateinit var dnsLogDao: DnsLogDao
     private lateinit var firewallRuleDao: FirewallRuleDao
     private lateinit var appNameResolver: AppNameResolver
@@ -132,6 +153,7 @@ class RootProxyService : Service() {
         val koin = getKoin()
         appPrefs = koin.get()
         filterRepo = koin.get()
+        profileManager = koin.get()
         dnsLogDao = koin.get()
         firewallRuleDao = koin.get()
 
@@ -159,7 +181,8 @@ class RootProxyService : Service() {
 
         when (intent?.action) {
             ACTION_STOP -> {
-                stopProxy()
+                val markProtectionDisabled = intent.getBooleanExtra(EXTRA_MARK_PROTECTION_DISABLED, true)
+                stopProxy(markProtectionDisabled = markProtectionDisabled)
                 return START_NOT_STICKY
             }
             ACTION_PAUSE_1H -> {
@@ -167,13 +190,45 @@ class RootProxyService : Service() {
                 return START_NOT_STICKY
             }
             ACTION_RESTART -> {
+                if (!isRootRoutingAllowed()) {
+                    stopProxy(markProtectionDisabled = false)
+                    return START_NOT_STICKY
+                }
+                stopVpnIfActive()
                 restartProxy()
                 return START_STICKY
             }
+            ACTION_RELOAD -> {
+                if (!isRootRoutingAllowed()) {
+                    stopProxy(markProtectionDisabled = false)
+                    return START_NOT_STICKY
+                }
+                stopVpnIfActive()
+                reloadProxyRuntime()
+                return START_STICKY
+            }
             else -> {
+                if (!isRootRoutingAllowed()) {
+                    Timber.w("Ignoring Root Proxy start while non-root routing mode is selected")
+                    stopSelf()
+                    return START_NOT_STICKY
+                }
+                stopVpnIfActive()
                 startProxy(startedFromBoot)
                 return START_STICKY
             }
+        }
+    }
+
+    private fun isRootRoutingAllowed(): Boolean {
+        return runBlocking {
+            appPrefs.getRoutingModeSnapshot() == AppPreferences.ROUTING_MODE_ROOT
+        }
+    }
+
+    private fun stopVpnIfActive() {
+        if (AdBlockVpnService.state.value != VpnState.STOPPED) {
+            AdBlockVpnService.stop(this, markProtectionDisabled = false)
         }
     }
 
@@ -184,6 +239,7 @@ class RootProxyService : Service() {
         }
         
         _state.value = VpnState.STARTING
+        _health.value = RootProxyHealth()
 
         createNotificationChannel()
         startForeground(NOTIFICATION_ID, buildNotification())
@@ -202,6 +258,7 @@ class RootProxyService : Service() {
                 filterRepo.loadCustomRules()
                 filterRepo.seedDefaultsIfNeeded()
                 filterRepo.fetchAndSyncRemoteFilterLists()
+                profileManager.reapplyActiveProfile()
                 val result = filterRepo.loadAllEnabledFilters()
                 Timber.d("Filters loaded for Root Proxy mode: ${result.getOrDefault(0)} domains")
 
@@ -256,7 +313,16 @@ class RootProxyService : Service() {
                     } else {
                         val engineStarted = goTunnelAdapter.startStandalone(port = 15353)
                         if (engineStarted) {
-                            if (IptablesManager.setupRules(this@RootProxyService, whitelistUids = whitelistedUids)) {
+                            val setupResult = IptablesManager.setupRulesDetailed(
+                                this@RootProxyService,
+                                whitelistUids = whitelistedUids
+                            )
+                            updateRootHealth(
+                                engineReady = true,
+                                routingActive = setupResult.ipv4Active,
+                                ipv6RoutingActive = setupResult.ipv6Active
+                            )
+                            if (setupResult.usable) {
                                 proxyStarted = true
                             } else {
                                 goTunnelAdapter.stop() // stop engine if iptables fails
@@ -272,7 +338,7 @@ class RootProxyService : Service() {
 
                 if (!proxyStarted) {
                     Timber.e("Failed to start Root Proxy after ${retryManager.getMaxRetries()} attempts")
-                    stopProxy()
+                    stopProxy(markProtectionDisabled = false)
                     showStartFailedNotification()
                     return@launch
                 }
@@ -288,6 +354,7 @@ class RootProxyService : Service() {
                 appNameResolver.startSnapshotter(serviceScope)
 
                 _state.value = VpnState.RUNNING
+                appPrefs.setProtectionDesired(true)
                 if (!preserveUptimeOnRestart || startTimestamp == 0L) {
                     startTimestamp = System.currentTimeMillis()
                 }
@@ -296,31 +363,44 @@ class RootProxyService : Service() {
 
                 updateNotification()
                 startNotificationUpdates()
+                startFilterUpdates()
 
                 // 4. Start watchdog
                 startWatchdog()
             } catch (e: Exception) {
                 Timber.e(e, "Failed to start Root Proxy mode")
-                IptablesManager.teardownRules()
-                stopSelf()
+                stopProxy(markProtectionDisabled = false)
             }
         }
     }
 
-    private fun stopProxy(showPausedNotification: Boolean = false) {
+    private fun stopProxy(
+        showPausedNotification: Boolean = false,
+        markProtectionDisabled: Boolean = true,
+        restorePrivateDns: Boolean = true,
+    ) {
         Timber.d("Stopping Root Proxy mode")
         _state.value = VpnState.STOPPING
         watchdogJob?.cancel()
+        filterUpdateJob?.cancel()
         stopNotificationUpdates()
         appNameResolver.stopSnapshotter()
 
+        if (markProtectionDisabled) {
+            ServiceController.cancelResumeWork(this)
+            runBlocking {
+                appPrefs.setProtectionDesired(false)
+            }
+        }
+
         // Teardown iptables rules (critical — prevents internet loss)
-        IptablesManager.teardownRules()
+        IptablesManager.teardownRules(restorePrivateDns = restorePrivateDns)
 
         // Stop Go engine
         goTunnelAdapter.stop()
 
         _state.value = VpnState.STOPPED
+        _health.value = RootProxyHealth()
         startTimestamp = 0L
         if (showPausedNotification) {
             stopForeground(STOP_FOREGROUND_DETACH)
@@ -345,7 +425,7 @@ class RootProxyService : Service() {
         )
 
         // Stop proxy and show paused notification
-        stopProxy(showPausedNotification = true)
+        stopProxy(showPausedNotification = true, markProtectionDisabled = false)
     }
 
     /**
@@ -361,6 +441,7 @@ class RootProxyService : Service() {
         Timber.d("Restarting Root Proxy to apply new settings")
 
         watchdogJob?.cancel()
+        filterUpdateJob?.cancel()
         stopNotificationUpdates()
         appNameResolver.stopSnapshotter()
 
@@ -369,7 +450,8 @@ class RootProxyService : Service() {
             goTunnelAdapter.stop()
 
             // Teardown iptables
-            IptablesManager.teardownRules()
+            IptablesManager.teardownRules(restorePrivateDns = false)
+            _health.value = RootProxyHealth()
 
             // Brief delay to let resources clean up
             delay(1000L)
@@ -381,6 +463,102 @@ class RootProxyService : Service() {
         }
     }
 
+    private fun reloadProxyRuntime() {
+        if (_state.value != VpnState.RUNNING) return
+        serviceScope.launch(Dispatchers.IO) {
+            reloadProxyRuntimeNow()
+        }
+    }
+
+    private suspend fun reloadProxyRuntimeNow() {
+        try {
+            Timber.d("Reloading Root Proxy runtime configuration")
+            filterRepo.loadWhitelist()
+            filterRepo.loadCustomRules()
+            val result = filterRepo.loadAllEnabledFilters()
+            Timber.d("Reloaded filters for Root Proxy: ${result.getOrDefault(0)} domains")
+            goTunnelAdapter.updateTries()
+            goTunnelAdapter.updateCosmeticRules()
+
+            val protocol = appPrefs.dnsProtocol.first().name
+            val primary = appPrefs.upstreamDns.first()
+            val fallback = appPrefs.fallbackDns.first()
+            val dohUrl = appPrefs.dohUrl.first()
+            val safeSearch = appPrefs.safeSearchEnabled.first()
+            val youtubeSafe = appPrefs.youtubeRestrictedMode.first()
+            val responseType = appPrefs.dnsResponseType.first()
+
+            goTunnelAdapter.configureDns(protocol, primary, fallback, dohUrl)
+            goTunnelAdapter.configureSafeSearch(safeSearch, youtubeSafe)
+            goTunnelAdapter.setBlockResponseType(responseType)
+
+            val firewallEnabled = appPrefs.firewallEnabled.first()
+            if (firewallEnabled) {
+                val fwManager = FirewallManager(this@RootProxyService, firewallRuleDao)
+                fwManager.loadRules()
+                firewallManager = fwManager
+            } else {
+                firewallManager = null
+            }
+
+            whitelistedUids = appPrefs.getWhitelistedAppsSnapshot().mapNotNull { pkg ->
+                try {
+                    packageManager.getApplicationInfo(pkg, 0).uid
+                } catch (e: Exception) {
+                    Timber.w("Whitelisted app not found, skipping: $pkg")
+                    null
+                }
+            }.distinct()
+
+            val setupResult = IptablesManager.setupRulesDetailed(
+                this@RootProxyService,
+                whitelistUids = whitelistedUids
+            )
+            val engineHealthy = goTunnelAdapter.isStandaloneHealthy()
+            updateRootHealth(
+                engineReady = engineHealthy,
+                routingActive = setupResult.ipv4Active,
+                ipv6RoutingActive = setupResult.ipv6Active
+            )
+
+            if (!engineHealthy || !setupResult.usable) {
+                Timber.w("Root Proxy reload left protection unhealthy; restarting")
+                restartProxy()
+                return
+            }
+
+            updateNotification()
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to reload Root Proxy runtime")
+            restartProxy()
+        }
+    }
+
+    private fun startFilterUpdates() {
+        filterUpdateJob?.cancel()
+        filterUpdateJob = serviceScope.launch {
+            filterRepo.domainCountFlow.drop(1).collectLatest { count ->
+                if (_state.value == VpnState.RUNNING) {
+                    Timber.d("Root Proxy filter count changed to $count; updating Go tries without restarting")
+                    reloadProxyRuntimeNow()
+                }
+            }
+        }
+    }
+
+    private fun updateRootHealth(
+        engineReady: Boolean,
+        routingActive: Boolean,
+        ipv6RoutingActive: Boolean,
+    ) {
+        _health.value = RootProxyHealth(
+            engineReady = engineReady,
+            routingActive = routingActive,
+            ipv6RoutingActive = ipv6RoutingActive,
+            lastDnsActivity = goTunnelAdapter.lastDnsActivityMillis().takeIf { it > 0L },
+        )
+    }
+
     /**
      * Watchdog monitors Go engine health every 10 seconds.
      * If the engine is dead, teardown iptables to prevent internet loss.
@@ -390,19 +568,39 @@ class RootProxyService : Service() {
         watchdogJob = serviceScope.launch {
             while (isActive && _state.value == VpnState.RUNNING) {
                 delay(10_000)
-                // TODO: Check Go engine health
-                // if (!goEngine.isRunning()) {
-                //     Timber.w("Go engine died — tearing down iptables")
-                //     IptablesManager.teardownRules()
-                //     isRunning = false
-                //     stopSelf()
-                //     break
-                // }
+                val engineHealthy = goTunnelAdapter.isStandaloneHealthy()
+                val status = IptablesManager.getStatus()
+                updateRootHealth(
+                    engineReady = engineHealthy,
+                    routingActive = status.ipv4Active,
+                    ipv6RoutingActive = status.ipv6Active
+                )
 
-                // For now, check if iptables rules are still active
-                if (!IptablesManager.isActive()) {
-                    Timber.w("iptables rules disappeared — re-applying")
-                    IptablesManager.setupRules(this@RootProxyService, whitelistUids = whitelistedUids)
+                if (!engineHealthy) {
+                    Timber.w("Root Proxy Go engine health check failed — restarting")
+                    restartProxy()
+                    break
+                }
+
+                if (!status.ipv4Active) {
+                    Timber.w("Root Proxy IPv4 iptables rules disappeared — re-applying")
+                    val setupResult = IptablesManager.setupRulesDetailed(
+                        this@RootProxyService,
+                        whitelistUids = whitelistedUids
+                    )
+                    val stillHealthy = goTunnelAdapter.isStandaloneHealthy()
+                    updateRootHealth(
+                        engineReady = stillHealthy,
+                        routingActive = setupResult.ipv4Active,
+                        ipv6RoutingActive = setupResult.ipv6Active
+                    )
+                    if (!setupResult.usable || !stillHealthy) {
+                        Timber.w("Root Proxy routing could not be restored — restarting")
+                        restartProxy()
+                        break
+                    }
+                } else if (!status.ipv6Active) {
+                    Timber.w("Root Proxy IPv6 interception inactive; reporting partial protection")
                 }
             }
         }
@@ -413,16 +611,17 @@ class RootProxyService : Service() {
         _state.value = VpnState.STOPPED
         startTimestamp = 0L
         watchdogJob?.cancel()
+        filterUpdateJob?.cancel()
         stopNotificationUpdates()
         if (::appNameResolver.isInitialized) appNameResolver.stopSnapshotter()
-        IptablesManager.teardownRules()
+        _health.value = RootProxyHealth()
+        IptablesManager.teardownRules(restorePrivateDns = true)
         serviceScope.cancel()
         super.onDestroy()
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        Timber.d("RootProxyService onTaskRemoved — teardown iptables")
-        IptablesManager.teardownRules()
+        Timber.d("RootProxyService onTaskRemoved — keeping foreground protection active")
         super.onTaskRemoved(rootIntent)
     }
 

--- a/app/src/main/java/app/pwhs/blockads/service/ServiceController.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/ServiceController.kt
@@ -2,61 +2,279 @@ package app.pwhs.blockads.service
 
 import android.content.Context
 import app.pwhs.blockads.data.datastore.AppPreferences
+import app.pwhs.blockads.worker.RootProxyResumeWorker
+import app.pwhs.blockads.worker.VpnResumeWorker
+import androidx.work.WorkManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import timber.log.Timber
 
 /**
- * Unified service controller that dispatches restart/stop requests
- * to the correct service based on the current routing mode.
- *
- * This avoids the need to check routing mode at every ViewModel callsite.
+ * Single entry point for starting, stopping, restarting, and reconciling the
+ * protection services. The preference stores the desired routing mode; this
+ * controller makes the real services match it.
  */
 object ServiceController {
+    const val FAIL_REASON_ROOT_ENGINE = "root_engine_unhealthy"
+    const val FAIL_REASON_ROOT_ROUTING = "root_routing_inactive"
 
-    /**
-     * Request a restart of whichever ad-blocking service is currently running.
-     * If Root Proxy mode is active, restarts RootProxyService.
-     * If VPN mode is active, restarts AdBlockVpnService.
-     * Safe to call from any thread.
-     */
-    fun requestRestart(context: Context) {
-        // Check both services — at least one might be running
-        if (RootProxyService.isRunning) {
-            RootProxyService.requestRestart(context)
-        }
-        if (AdBlockVpnService.isRunning) {
-            AdBlockVpnService.requestRestart(context)
-        }
+    private const val SERVICE_SWITCH_DELAY_MS = 800L
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    fun protectionHealthFlow(appPrefs: AppPreferences): Flow<ProtectionHealth> = combine(
+        AdBlockVpnService.state,
+        RootProxyService.state,
+        RootProxyService.health,
+        appPrefs.routingMode
+    ) { vpnState, rootState, rootHealth, desiredMode ->
+        val state = deriveActualState(vpnState, rootState, rootHealth, desiredMode)
+        ProtectionHealth(
+            serviceRunning = state.isServiceActive(),
+            engineReady = when (actualMode(vpnState, rootState, desiredMode)) {
+                ActualProtectionMode.ROOT -> rootHealth.engineReady
+                ActualProtectionMode.VPN,
+                ActualProtectionMode.WIREGUARD -> vpnState == VpnState.RUNNING
+                ActualProtectionMode.CONFLICT -> false
+                ActualProtectionMode.NONE -> false
+            },
+            routingActive = when (actualMode(vpnState, rootState, desiredMode)) {
+                ActualProtectionMode.ROOT -> rootHealth.routingActive
+                ActualProtectionMode.VPN,
+                ActualProtectionMode.WIREGUARD -> vpnState == VpnState.RUNNING
+                ActualProtectionMode.CONFLICT -> false
+                ActualProtectionMode.NONE -> false
+            },
+            ipv6RoutingActive = when (actualMode(vpnState, rootState, desiredMode)) {
+                ActualProtectionMode.ROOT -> rootHealth.ipv6RoutingActive
+                ActualProtectionMode.VPN,
+                ActualProtectionMode.WIREGUARD -> true
+                ActualProtectionMode.CONFLICT,
+                ActualProtectionMode.NONE -> false
+            },
+            lastDnsActivity = rootHealth.lastDnsActivity,
+            actualMode = actualMode(vpnState, rootState, desiredMode),
+            desiredMode = desiredMode,
+            state = state,
+        )
     }
 
-    /**
-     * Start the VPN or Root Proxy depending on AppPreferences.
-     */
-    fun requestStart(context: Context) {
-        CoroutineScope(Dispatchers.IO).launch {
-            val appPrefs = AppPreferences(context)
-            val routingMode = appPrefs.routingMode.first()
+    fun deriveActualState(
+        vpnState: VpnState,
+        rootState: VpnState,
+        rootHealth: RootProxyHealth,
+        desiredMode: String,
+    ): ActualProtectionState {
+        val vpnActive = vpnState.isActiveState()
+        val rootActive = rootState.isActiveState()
 
-            if (routingMode == AppPreferences.ROUTING_MODE_ROOT) {
-                RootProxyService.start(context)
+        if (vpnActive && rootActive) return ActualProtectionState.InconsistentBothRunning
+
+        if (rootState == VpnState.RUNNING) {
+            if (desiredMode != AppPreferences.ROUTING_MODE_ROOT) {
+                return ActualProtectionState.InconsistentWrongMode
+            }
+            if (!rootHealth.engineReady) {
+                return ActualProtectionState.Failed(FAIL_REASON_ROOT_ENGINE)
+            }
+            if (!rootHealth.routingActive) {
+                return ActualProtectionState.Failed(FAIL_REASON_ROOT_ROUTING)
+            }
+            return ActualProtectionState.RunningRoot
+        }
+
+        if (vpnState == VpnState.RUNNING) {
+            if (desiredMode == AppPreferences.ROUTING_MODE_ROOT) {
+                return ActualProtectionState.InconsistentWrongMode
+            }
+            return if (desiredMode == AppPreferences.ROUTING_MODE_WIREGUARD) {
+                ActualProtectionState.RunningWireGuard
             } else {
-                AdBlockVpnService.start(context)
+                ActualProtectionState.RunningVpn
             }
         }
+
+        if (rootState == VpnState.STARTING || rootState == VpnState.RESTARTING) {
+            return if (desiredMode == AppPreferences.ROUTING_MODE_ROOT) {
+                ActualProtectionState.StartingRoot
+            } else {
+                ActualProtectionState.InconsistentWrongMode
+            }
+        }
+
+        if (vpnState == VpnState.STARTING || vpnState == VpnState.RESTARTING) {
+            return if (desiredMode == AppPreferences.ROUTING_MODE_ROOT) {
+                ActualProtectionState.InconsistentWrongMode
+            } else {
+                ActualProtectionState.StartingVpn
+            }
+        }
+
+        return ActualProtectionState.Stopped
     }
 
-    /**
-     * Stop whichever service is currently running.
-     */
+    fun actualMode(
+        vpnState: VpnState = AdBlockVpnService.state.value,
+        rootState: VpnState = RootProxyService.state.value,
+        desiredMode: String,
+    ): ActualProtectionMode {
+        val vpnActive = vpnState.isActiveState()
+        val rootActive = rootState.isActiveState()
+
+        return when {
+            vpnActive && rootActive -> ActualProtectionMode.CONFLICT
+            rootActive -> ActualProtectionMode.ROOT
+            vpnActive && desiredMode == AppPreferences.ROUTING_MODE_WIREGUARD -> ActualProtectionMode.WIREGUARD
+            vpnActive -> ActualProtectionMode.VPN
+            else -> ActualProtectionMode.NONE
+        }
+    }
+
+    fun requestStart(context: Context, startedFromBoot: Boolean = false) {
+        scope.launch {
+            requestStartNow(context.applicationContext, startedFromBoot)
+        }
+    }
+
+    suspend fun requestStartNow(context: Context, startedFromBoot: Boolean = false) {
+        val appContext = context.applicationContext
+        val appPrefs = AppPreferences(appContext)
+        appPrefs.setProtectionDesired(true)
+        appPrefs.setPausedByTrusted(false)
+        cancelResumeWork(appContext)
+        reconcileToMode(appContext, appPrefs.routingMode.first(), startIfDesired = true, startedFromBoot = startedFromBoot)
+    }
+
     fun requestStop(context: Context) {
-        if (RootProxyService.isRunning) {
-            RootProxyService.stop(context)
+        scope.launch {
+            requestStopNow(context.applicationContext, markProtectionDisabled = true)
         }
-        if (AdBlockVpnService.isRunning) {
-            AdBlockVpnService.stop(context)
+    }
+
+    fun requestPause(context: Context) {
+        scope.launch {
+            requestStopNow(context.applicationContext, markProtectionDisabled = false)
         }
+    }
+
+    suspend fun requestStopNow(context: Context, markProtectionDisabled: Boolean) {
+        val appContext = context.applicationContext
+        val appPrefs = AppPreferences(appContext)
+        cancelResumeWork(appContext)
+        if (markProtectionDisabled) {
+            appPrefs.setProtectionDesired(false)
+            appPrefs.setPausedByTrusted(false)
+        }
+        stopServices(appContext, markProtectionDisabled = markProtectionDisabled)
+    }
+
+    fun requestRestart(context: Context) {
+        scope.launch {
+            requestRestartNow(context.applicationContext)
+        }
+    }
+
+    suspend fun requestRestartNow(context: Context) {
+        val appContext = context.applicationContext
+        val appPrefs = AppPreferences(appContext)
+        val desiredMode = appPrefs.routingMode.first()
+        val shouldBeRunning = appPrefs.protectionDesired.first() ||
+            AdBlockVpnService.state.value.isActiveState() ||
+            RootProxyService.state.value.isActiveState()
+
+        if (!shouldBeRunning) return
+
+        reconcileToMode(
+            context = appContext,
+            targetMode = desiredMode,
+            startIfDesired = true,
+            restartTarget = true,
+        )
+    }
+
+    suspend fun reconcileToMode(
+        context: Context,
+        targetMode: String,
+        startIfDesired: Boolean = true,
+        restartTarget: Boolean = false,
+        startedFromBoot: Boolean = false,
+    ) {
+        val appContext = context.applicationContext
+        val appPrefs = AppPreferences(appContext)
+        appPrefs.setRoutingMode(targetMode)
+        cancelResumeWork(appContext)
+
+        val protectionDesired = appPrefs.protectionDesired.first()
+        val shouldRun = startIfDesired && (
+            protectionDesired ||
+                AdBlockVpnService.state.value.isActiveState() ||
+                RootProxyService.state.value.isActiveState()
+            )
+
+        if (targetMode == AppPreferences.ROUTING_MODE_ROOT) {
+            if (AdBlockVpnService.state.value.isActiveState()) {
+                AdBlockVpnService.stop(appContext, markProtectionDisabled = false)
+                delay(SERVICE_SWITCH_DELAY_MS)
+            }
+
+            if (shouldRun) {
+                if (RootProxyService.state.value == VpnState.RUNNING && restartTarget) {
+                    RootProxyService.requestReload(appContext)
+                } else if (!RootProxyService.state.value.isActiveState()) {
+                    RootProxyService.start(appContext, startedFromBoot = startedFromBoot)
+                }
+            } else if (RootProxyService.state.value.isActiveState()) {
+                RootProxyService.stop(appContext, markProtectionDisabled = false)
+            }
+            return
+        }
+
+        if (RootProxyService.state.value.isActiveState()) {
+            RootProxyService.stop(appContext, markProtectionDisabled = false)
+            delay(SERVICE_SWITCH_DELAY_MS)
+        }
+
+        if (shouldRun) {
+            if (AdBlockVpnService.state.value == VpnState.RUNNING && restartTarget) {
+                AdBlockVpnService.requestRestart(appContext)
+            } else if (!AdBlockVpnService.state.value.isActiveState()) {
+                AdBlockVpnService.start(appContext, startedFromBoot = startedFromBoot)
+            }
+        } else if (AdBlockVpnService.state.value.isActiveState()) {
+            AdBlockVpnService.stop(appContext, markProtectionDisabled = false)
+        }
+    }
+
+    fun cancelResumeWork(context: Context) {
+        runCatching {
+            val workManager = WorkManager.getInstance(context.applicationContext)
+            workManager.cancelUniqueWork(VpnResumeWorker.WORK_NAME)
+            workManager.cancelUniqueWork(RootProxyResumeWorker.WORK_NAME)
+        }.onFailure {
+            Timber.w(it, "Failed to cancel resume work")
+        }
+    }
+
+    private fun stopServices(context: Context, markProtectionDisabled: Boolean) {
+        if (AdBlockVpnService.state.value.isActiveState()) {
+            AdBlockVpnService.stop(context, markProtectionDisabled = markProtectionDisabled)
+        }
+        if (RootProxyService.state.value.isActiveState()) {
+            RootProxyService.stop(context, markProtectionDisabled = markProtectionDisabled)
+        }
+    }
+
+    private fun VpnState.isActiveState(): Boolean = when (this) {
+        VpnState.STARTING,
+        VpnState.RUNNING,
+        VpnState.STOPPING,
+        VpnState.RESTARTING -> true
+        VpnState.STOPPED -> false
     }
 }

--- a/app/src/main/java/app/pwhs/blockads/service/TrustedNetworkManager.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/TrustedNetworkManager.kt
@@ -110,7 +110,7 @@ class TrustedNetworkManager(
                         onTrusted && running -> {
                             Timber.d("Trusted network '$ssid' — pausing BlockAds")
                             appPrefs.setPausedByTrusted(true, ssid ?: "")
-                            ServiceController.requestStop(context)
+                            ServiceController.requestPause(context)
                             showPausedNotification(ssid ?: "")
                         }
                         // Left the trusted network and we had paused → resume.

--- a/app/src/main/java/app/pwhs/blockads/ui/filter/detail/FilterDetailScreen.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/filter/detail/FilterDetailScreen.kt
@@ -441,10 +441,10 @@ fun FilterDetailScreen(
                 }
             }
 
-            // Test a Domain section
+            // Filter-file domain lookup section
             item {
                 Text(
-                    "Test a Domain",
+                    stringResource(R.string.filter_detail_test_domain_title),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold
                 )
@@ -492,7 +492,11 @@ fun FilterDetailScreen(
                                 )
                                 Spacer(modifier = Modifier.width(8.dp))
                                 Text(
-                                    text = if (isBlocked) "Domain is BLOCKED by this filter" else "Domain is ALLOWED by this filter",
+                                    text = if (isBlocked) {
+                                        stringResource(R.string.filter_detail_domain_in_filter)
+                                    } else {
+                                        stringResource(R.string.filter_detail_domain_not_in_filter)
+                                    },
                                     color = if (isBlocked) DangerRed else Color(0xFF4CAF50),
                                     fontWeight = FontWeight.Bold
                                 )

--- a/app/src/main/java/app/pwhs/blockads/ui/home/HomeScreen.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/home/HomeScreen.kt
@@ -3,6 +3,7 @@ package app.pwhs.blockads.ui.home
 import android.graphics.drawable.Drawable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -54,16 +55,23 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.pwhs.blockads.R
 import app.pwhs.blockads.data.datastore.AppPreferences
 import app.pwhs.blockads.data.repository.FilterListRepository
+import app.pwhs.blockads.service.ActualProtectionMode
+import app.pwhs.blockads.service.ProtectionProblem
 import app.pwhs.blockads.ui.home.component.DailyStatsChart
 import app.pwhs.blockads.ui.home.component.HomeAppBar
 import app.pwhs.blockads.ui.home.component.PowerButton
@@ -83,6 +91,8 @@ import app.pwhs.blockads.utils.profileIcon
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import org.koin.androidx.compose.koinViewModel
 import java.util.Locale
+
+private const val MAGISK_DISABLE_IPV6_URL = "https://github.com/njallam/magisk-disable-ipv6"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -112,6 +122,9 @@ fun HomeScreen(
     val activeProfile by viewModel.activeProfile.collectAsStateWithLifecycle()
     val securityFilterIds by viewModel.securityFilterIds.collectAsStateWithLifecycle()
     val routingMode by viewModel.routingMode.collectAsStateWithLifecycle()
+    val actualProtectionMode by viewModel.actualProtectionMode.collectAsStateWithLifecycle()
+    val protectionProblem by viewModel.protectionProblem.collectAsStateWithLifecycle()
+    val partialIpv6Warning by viewModel.partialIpv6Warning.collectAsStateWithLifecycle()
     val privateDnsWarning by viewModel.privateDnsWarning.collectAsStateWithLifecycle()
     val pausedByTrusted by viewModel.pausedByTrusted.collectAsStateWithLifecycle()
     val pausedTrustedSsid by viewModel.pausedTrustedSsid.collectAsStateWithLifecycle()
@@ -182,11 +195,85 @@ fun HomeScreen(
                 }
             }
 
+            protectionProblem?.let { problem ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 16.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Warning,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column {
+                            Text(
+                                text = stringResource(R.string.protection_problem_title),
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer
+                            )
+                            Text(
+                                text = stringResource(
+                                    when (problem) {
+                                        ProtectionProblem.BOTH_SERVICES_RUNNING -> R.string.protection_problem_both_services
+                                        ProtectionProblem.WRONG_MODE_RUNNING -> R.string.protection_problem_wrong_mode
+                                        ProtectionProblem.ROOT_ENGINE_UNHEALTHY -> R.string.protection_problem_root_engine
+                                        ProtectionProblem.ROOT_ROUTING_INACTIVE -> R.string.protection_problem_root_routing
+                                    }
+                                ),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (partialIpv6Warning && protectionProblem == null) {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 16.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.tertiaryContainer
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Warning,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onTertiaryContainer
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column {
+                            Text(
+                                text = stringResource(R.string.protection_partial_title),
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onTertiaryContainer
+                            )
+                            PartialIpv6WarningText()
+                        }
+                    }
+                }
+            }
+
             // Status text
             Text(
                 text = when {
                     vpnStopping -> stringResource(R.string.status_disconnecting)
                     vpnConnecting -> stringResource(R.string.status_connecting)
+                    protectionProblem != null -> stringResource(R.string.status_protection_issue)
                     vpnEnabled -> stringResource(R.string.status_protected)
                     showTrustedPause -> stringResource(R.string.status_paused)
                     else -> stringResource(R.string.status_unprotected)
@@ -195,6 +282,7 @@ fun HomeScreen(
                 color = when {
                     vpnStopping -> SecurityOrange
                     vpnConnecting -> AccentBlue
+                    protectionProblem != null -> DangerRed
                     vpnEnabled -> MaterialTheme.colorScheme.primary
                     showTrustedPause -> SecurityOrange
                     else -> DangerRed
@@ -209,6 +297,7 @@ fun HomeScreen(
                 text = when {
                     vpnStopping -> stringResource(if (isRootMode) R.string.home_disconnecting_desc_root else R.string.home_disconnecting_desc)
                     vpnConnecting -> stringResource(if (isRootMode) R.string.home_connecting_desc_root else R.string.home_connecting_desc)
+                    protectionProblem != null -> stringResource(R.string.home_protection_issue_desc)
                     vpnEnabled -> stringResource(R.string.home_protected_desc)
                     showTrustedPause -> stringResource(R.string.home_paused_trusted_short)
                     else -> stringResource(R.string.home_unprotected_desc)
@@ -251,10 +340,16 @@ fun HomeScreen(
                         .padding(horizontal = 10.dp, vertical = 4.dp)
                 ) {
                     Text(
-                        text = when (routingMode) {
-                            AppPreferences.ROUTING_MODE_ROOT -> "Root Proxy Mode"
-                            AppPreferences.ROUTING_MODE_WIREGUARD -> "WireGuard Mode"
-                            else -> "Local VPN Mode"
+                        text = when (actualProtectionMode) {
+                            ActualProtectionMode.ROOT -> "Root Proxy Mode"
+                            ActualProtectionMode.WIREGUARD -> "WireGuard Mode"
+                            ActualProtectionMode.VPN -> "Local VPN Mode"
+                            ActualProtectionMode.CONFLICT -> stringResource(R.string.protection_mode_conflict)
+                            ActualProtectionMode.NONE -> when (routingMode) {
+                                AppPreferences.ROUTING_MODE_ROOT -> "Root Proxy Mode"
+                                AppPreferences.ROUTING_MODE_WIREGUARD -> "WireGuard Mode"
+                                else -> "Local VPN Mode"
+                            }
                         },
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
@@ -700,4 +795,49 @@ fun HomeScreen(
         }
 
     }
+}
+
+@Composable
+private fun PartialIpv6WarningText(modifier: Modifier = Modifier) {
+    val uriHandler = LocalUriHandler.current
+    val body = stringResource(R.string.protection_partial_ipv6)
+    val linkText = stringResource(R.string.protection_partial_ipv6_magisk_link)
+    val linkColor = MaterialTheme.colorScheme.primary
+    val annotatedText = remember(body, linkText, linkColor) {
+        buildAnnotatedString {
+            val linkStart = body.indexOf(linkText)
+            if (linkStart < 0) {
+                append(body)
+                return@buildAnnotatedString
+            }
+
+            append(body.substring(0, linkStart))
+            pushStringAnnotation(tag = "url", annotation = MAGISK_DISABLE_IPV6_URL)
+            withStyle(
+                SpanStyle(
+                    color = linkColor,
+                    fontWeight = FontWeight.SemiBold,
+                    textDecoration = TextDecoration.Underline
+                )
+            ) {
+                append(linkText)
+            }
+            pop()
+            append(body.substring(linkStart + linkText.length))
+        }
+    }
+
+    ClickableText(
+        text = annotatedText,
+        modifier = modifier,
+        style = MaterialTheme.typography.bodySmall.copy(
+            color = MaterialTheme.colorScheme.onTertiaryContainer
+        ),
+        onClick = { offset ->
+            annotatedText
+                .getStringAnnotations(tag = "url", start = offset, end = offset)
+                .firstOrNull()
+                ?.let { uriHandler.openUri(it.item) }
+        }
+    )
 }

--- a/app/src/main/java/app/pwhs/blockads/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/home/HomeViewModel.kt
@@ -1,7 +1,6 @@
 package app.pwhs.blockads.ui.home
 
 import android.content.Context
-import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.pwhs.blockads.data.dao.DnsLogDao
@@ -14,9 +13,13 @@ import app.pwhs.blockads.data.entities.HourlyStat
 import app.pwhs.blockads.data.entities.ProtectionProfile
 import app.pwhs.blockads.data.entities.TopBlockedDomain
 import app.pwhs.blockads.data.repository.FilterListRepository
+import app.pwhs.blockads.service.ActualProtectionMode
 import app.pwhs.blockads.service.AdBlockVpnService
-import app.pwhs.blockads.service.VpnState
+import app.pwhs.blockads.service.ActualProtectionState
+import app.pwhs.blockads.service.ProtectionHealth
+import app.pwhs.blockads.service.ProtectionProblem
 import app.pwhs.blockads.service.RootProxyService
+import app.pwhs.blockads.service.ServiceController
 import app.pwhs.blockads.data.datastore.AppPreferences
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,9 +27,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -51,28 +52,50 @@ class HomeViewModel(
     val pausedTrustedSsid: StateFlow<String> = appPrefs.pausedTrustedSsid
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "")
 
-    // ── Reactive VPN state (derived from the single source of truth) ──
-    val vpnEnabled: StateFlow<Boolean> = combine(
-        AdBlockVpnService.state,
-        RootProxyService.state
-    ) { state1, state2 ->
-        state1 == VpnState.RUNNING || state2 == VpnState.RUNNING
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AdBlockVpnService.isRunning || RootProxyService.isRunning)
+    val protectionHealth: StateFlow<ProtectionHealth> = ServiceController
+        .protectionHealthFlow(appPrefs)
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5000),
+            ProtectionHealth(
+                serviceRunning = false,
+                engineReady = false,
+                routingActive = false,
+                ipv6RoutingActive = false,
+                lastDnsActivity = null,
+                actualMode = ActualProtectionMode.NONE,
+                desiredMode = AppPreferences.ROUTING_MODE_DIRECT,
+                state = ActualProtectionState.Stopped,
+            )
+        )
 
-    val vpnConnecting: StateFlow<Boolean> = combine(
-        AdBlockVpnService.state,
-        RootProxyService.state
-    ) { state1, state2 ->
-        state1 == VpnState.STARTING || state1 == VpnState.RESTARTING ||
-        state2 == VpnState.STARTING || state2 == VpnState.RESTARTING
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AdBlockVpnService.isConnecting)
+    // ── Reactive protection state (derived from the central controller) ──
+    val vpnEnabled: StateFlow<Boolean> = protectionHealth
+        .map { it.serviceRunning }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AdBlockVpnService.isRunning || RootProxyService.isRunning)
+
+    val vpnConnecting: StateFlow<Boolean> = protectionHealth
+        .map { it.state == ActualProtectionState.StartingVpn || it.state == ActualProtectionState.StartingRoot }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AdBlockVpnService.isConnecting || RootProxyService.isConnecting)
 
     val vpnStopping: StateFlow<Boolean> = combine(
         AdBlockVpnService.state,
         RootProxyService.state
     ) { state1, state2 ->
-        state1 == VpnState.STOPPING || state2 == VpnState.STOPPING
+        state1 == app.pwhs.blockads.service.VpnState.STOPPING || state2 == app.pwhs.blockads.service.VpnState.STOPPING
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    val actualProtectionMode: StateFlow<ActualProtectionMode> = protectionHealth
+        .map { it.actualMode }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ActualProtectionMode.NONE)
+
+    val protectionProblem: StateFlow<ProtectionProblem?> = protectionHealth
+        .map { it.problem }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    val partialIpv6Warning: StateFlow<Boolean> = protectionHealth
+        .map { it.partialIpv6 }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     val blockedCount: StateFlow<Int> = dnsLogDao.getBlockedCount()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
@@ -122,10 +145,10 @@ class HomeViewModel(
     // the warning is VPN-mode only (#145).
     val privateDnsWarning: StateFlow<Boolean> = combine(
         vpnEnabled,
-        routingMode,
+        actualProtectionMode,
         AdBlockVpnService.privateDnsStrict
-    ) { enabled, mode, strict ->
-        enabled && mode != AppPreferences.ROUTING_MODE_ROOT && strict
+    ) { enabled, actualMode, strict ->
+        enabled && actualMode != ActualProtectionMode.ROOT && strict
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     init {
@@ -145,15 +168,7 @@ class HomeViewModel(
     }
 
     fun stopVpn(context: Context) {
-        if (RootProxyService.isRunning) {
-            RootProxyService.stop(context)
-        }
-        if (AdBlockVpnService.isRunning) {
-            val intent = Intent(context, AdBlockVpnService::class.java).apply {
-                action = AdBlockVpnService.ACTION_STOP
-            }
-            context.startService(intent)
-        }
+        ServiceController.requestStop(context)
     }
 
     fun preloadFilter() {

--- a/app/src/main/java/app/pwhs/blockads/ui/httpsfiltering/HttpsFilteringScreen.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/httpsfiltering/HttpsFilteringScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -48,6 +49,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.pwhs.blockads.R
+import app.pwhs.blockads.data.datastore.AppPreferences
 import app.pwhs.blockads.ui.httpsfiltering.component.BrowserRow
 import app.pwhs.blockads.ui.httpsfiltering.component.ExplanationCard
 import app.pwhs.blockads.ui.httpsfiltering.component.MasterToggleCard
@@ -68,11 +70,14 @@ fun HttpsFilteringScreen(
     val certExported by viewModel.certExported.collectAsStateWithLifecycle()
     val certStatus by viewModel.certStatus.collectAsStateWithLifecycle()
     val filterHttp3 by viewModel.filterHttp3.collectAsStateWithLifecycle()
+    val routingMode by viewModel.routingMode.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember { SnackbarHostState() }
     val resources = LocalResources.current
+    val isRootMode = routingMode == AppPreferences.ROUTING_MODE_ROOT
 
     val wgDisabledMsg = stringResource(R.string.https_filtering_wireguard_disabled)
+    val rootDisabledMsg = stringResource(R.string.https_filtering_root_disabled)
     val certSavedLegacyMsg = stringResource(R.string.https_filtering_cert_saved_legacy)
     val proxyStartedMsg = stringResource(R.string.https_filtering_started)
     val proxyStoppedMsg = stringResource(R.string.https_filtering_stopped)
@@ -126,6 +131,10 @@ fun HttpsFilteringScreen(
                 is HttpsFilteringEvent.WireGuardDisabledForHttps -> {
                     snackbarHostState.showSnackbar(wgDisabledMsg)
                 }
+
+                is HttpsFilteringEvent.RootModeUnsupported -> {
+                    snackbarHostState.showSnackbar(rootDisabledMsg)
+                }
             }
         }
     }
@@ -175,6 +184,38 @@ fun HttpsFilteringScreen(
                         isProxyRunning = isProxyRunning,
                         onToggle = { viewModel.toggleEnabled(it) }
                     )
+                }
+
+                if (isRootMode) {
+                    item {
+                        Card(
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(16.dp),
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer
+                            )
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Warning,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    modifier = Modifier.size(22.dp)
+                                )
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Text(
+                                    text = stringResource(R.string.https_filtering_root_disabled_desc),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                                )
+                            }
+                        }
+                    }
                 }
 
                 // ── Explanation Card ───────────────────────────────────

--- a/app/src/main/java/app/pwhs/blockads/ui/httpsfiltering/HttpsFilteringViewModel.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/httpsfiltering/HttpsFilteringViewModel.kt
@@ -18,9 +18,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
@@ -65,6 +67,8 @@ sealed class HttpsFilteringEvent {
     data object ProxyStopped : HttpsFilteringEvent()
     /** WireGuard routing was turned off because HTTPS filtering was enabled. */
     data object WireGuardDisabledForHttps : HttpsFilteringEvent()
+    /** Root mode cannot run HTTPS filtering because it uses DNS-only standalone mode. */
+    data object RootModeUnsupported : HttpsFilteringEvent()
 }
 
 // ── ViewModel ───────────────────────────────────────────────────────────────
@@ -80,6 +84,9 @@ class HttpsFilteringViewModel(
 
     private val _isEnabled = MutableStateFlow(false)
     val isEnabled: StateFlow<Boolean> = _isEnabled.asStateFlow()
+
+    val routingMode: StateFlow<String> = appPrefs.routingMode
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AppPreferences.ROUTING_MODE_DIRECT)
 
     private val _isProxyRunning = MutableStateFlow(false)
     val isProxyRunning: StateFlow<Boolean> = _isProxyRunning.asStateFlow()
@@ -123,6 +130,14 @@ class HttpsFilteringViewModel(
             appPrefs.setHttpsFilteringEnabled(enabled)
 
             if (enabled) {
+                if (appPrefs.getRoutingModeSnapshot() == AppPreferences.ROUTING_MODE_ROOT) {
+                    appPrefs.setHttpsFilteringEnabled(false)
+                    _isEnabled.value = false
+                    stopProxy()
+                    _events.emit(HttpsFilteringEvent.RootModeUnsupported)
+                    return@launch
+                }
+
                 // HTTPS filtering and WireGuard routing are mutually
                 // exclusive: TcpIpStack terminates flows and dials the
                 // destination directly, bypassing the WG tunnel. Turn
@@ -320,7 +335,11 @@ class HttpsFilteringViewModel(
 
             // Load saved preference
             val enabled = appPrefs.getHttpsFilteringEnabledSnapshot()
-            _isEnabled.value = enabled
+            val rootMode = appPrefs.getRoutingModeSnapshot() == AppPreferences.ROUTING_MODE_ROOT
+            _isEnabled.value = enabled && !rootMode
+            if (enabled && rootMode) {
+                appPrefs.setHttpsFilteringEnabled(false)
+            }
             _filterHttp3.value = appPrefs.getFilterHttp3Snapshot()
 
             // Load installed browsers

--- a/app/src/main/java/app/pwhs/blockads/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/onboarding/OnboardingViewModel.kt
@@ -6,6 +6,7 @@ import app.pwhs.blockads.data.datastore.AppPreferences
 import app.pwhs.blockads.data.entities.DnsProtocol
 import app.pwhs.blockads.data.entities.DnsProvider
 import app.pwhs.blockads.data.entities.DnsProviders
+import app.pwhs.blockads.data.entities.ProfileManager
 import app.pwhs.blockads.ui.onboarding.data.ProtectionLevel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,6 +16,7 @@ import androidx.lifecycle.viewModelScope
 
 class OnboardingViewModel(
     private val appPrefs: AppPreferences,
+    private val profileManager: ProfileManager,
     application: Application
 ) : AndroidViewModel(application) {
 
@@ -42,7 +44,8 @@ class OnboardingViewModel(
 
     suspend fun completeOnboarding() {
         // Save protection level
-        appPrefs.setProtectionLevel(_selectedProtectionLevel.value.name)
+        val protectionLevel = _selectedProtectionLevel.value.name
+        appPrefs.setProtectionLevel(protectionLevel)
 
         // Save DNS provider
         val provider = _selectedDnsProvider.value
@@ -58,6 +61,10 @@ class OnboardingViewModel(
         }
 
         appPrefs.setFallbackDns(selectFallbackDns(provider).ipAddress)
+
+        // Activate the matching preset profile so the real filter state
+        // matches the protection level shown during onboarding.
+        profileManager.switchToProtectionLevel(protectionLevel)
 
         // Mark onboarding as completed
         appPrefs.setOnboardingCompleted(true)

--- a/app/src/main/java/app/pwhs/blockads/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/settings/SettingsViewModel.kt
@@ -1,9 +1,7 @@
 package app.pwhs.blockads.ui.settings
 
 import android.app.Application
-import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import app.pwhs.blockads.R
@@ -22,7 +20,6 @@ import app.pwhs.blockads.data.entities.ProfileManager
 import app.pwhs.blockads.data.entities.SettingsBackup
 import app.pwhs.blockads.data.entities.WhitelistDomain
 import app.pwhs.blockads.data.repository.FilterListRepository
-import app.pwhs.blockads.service.AdBlockVpnService
 import app.pwhs.blockads.service.ServiceController
 import app.pwhs.blockads.ui.event.UiEvent
 import app.pwhs.blockads.ui.event.toast
@@ -30,10 +27,8 @@ import app.pwhs.blockads.utils.CustomRuleParser
 import app.pwhs.blockads.worker.DailySummaryScheduler
 import app.pwhs.blockads.worker.FilterUpdateScheduler
 import app.pwhs.blockads.service.IptablesManager
-import app.pwhs.blockads.service.RootProxyService
 import app.pwhs.blockads.utils.CrashReportingManager
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -174,35 +169,11 @@ class SettingsViewModel(
     }
 
     private suspend fun applyRoutingMode(mode: String) {
-        val oldMode = appPrefs.routingMode.first()
-        if (oldMode == mode) return
-
-        appPrefs.setRoutingMode(mode)
         val context = getApplication<Application>().applicationContext
-
-        val isRoot = mode == AppPreferences.ROUTING_MODE_ROOT
-
-        if (AdBlockVpnService.isRunning || RootProxyService.isRunning) {
-            if (isRoot) {
-                val stopIntent = Intent(context, AdBlockVpnService::class.java).apply {
-                    action = AdBlockVpnService.ACTION_STOP
-                }
-                context.startService(stopIntent)
-                delay(800)
-                RootProxyService.start(context)
-            } else {
-                RootProxyService.stop(context)
-                delay(800)
-                val startIntent = Intent(context, AdBlockVpnService::class.java).apply {
-                    action = AdBlockVpnService.ACTION_START
-                }
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    context.startForegroundService(startIntent)
-                } else {
-                    context.startService(startIntent)
-                }
-            }
+        if (mode == AppPreferences.ROUTING_MODE_ROOT && appPrefs.getHttpsFilteringEnabledSnapshot()) {
+            appPrefs.setHttpsFilteringEnabled(false)
         }
+        ServiceController.reconcileToMode(context, mode)
     }
 
     fun setAutoUpdateEnabled(enabled: Boolean) {

--- a/app/src/main/java/app/pwhs/blockads/widget/WidgetToggleReceiver.kt
+++ b/app/src/main/java/app/pwhs/blockads/widget/WidgetToggleReceiver.kt
@@ -3,11 +3,11 @@ package app.pwhs.blockads.widget
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import app.pwhs.blockads.MainActivity
 import app.pwhs.blockads.data.datastore.AppPreferences
 import app.pwhs.blockads.service.AdBlockVpnService
 import app.pwhs.blockads.service.RootProxyService
+import app.pwhs.blockads.service.ServiceController
 import app.pwhs.blockads.utils.VpnUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -45,21 +45,7 @@ class WidgetToggleReceiver : BroadcastReceiver() {
     private suspend fun toggleVpn(context: Context) {
         // Stop logic: evaluate running status of both services
         if (AdBlockVpnService.isRunning || RootProxyService.isRunning) {
-            // Stop AdBlockVpnService if running
-            if (AdBlockVpnService.isRunning) {
-                val stopIntent = Intent(context, AdBlockVpnService::class.java).apply {
-                    action = AdBlockVpnService.ACTION_STOP
-                }
-                context.startService(stopIntent)
-            }
-            
-            // Stop RootProxyService if running
-            if (RootProxyService.isRunning) {
-                val stopIntent = Intent(context, RootProxyService::class.java).apply {
-                    action = RootProxyService.ACTION_STOP
-                }
-                context.startService(stopIntent)
-            }
+            ServiceController.requestStop(context)
         } else {
             val appPrefs = AppPreferences(context)
             val routingMode = appPrefs.routingMode.first()
@@ -75,20 +61,8 @@ class WidgetToggleReceiver : BroadcastReceiver() {
                 return
             }
 
-            // Start logic: determine the service class and action dynamically based on routing mode
-            val targetClass = if (isRootMode) RootProxyService::class.java else AdBlockVpnService::class.java
-            val targetAction = if (isRootMode) RootProxyService.ACTION_START else AdBlockVpnService.ACTION_START
-
-            val startIntent = Intent(context, targetClass).apply {
-                action = targetAction
-            }
-            
             try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    context.startForegroundService(startIntent)
-                } else {
-                    context.startService(startIntent)
-                }
+                ServiceController.requestStart(context)
             } catch (e: Exception) {
                 Timber.w(e, "Cannot start VPN from widget, opening app")
                 val appIntent = Intent(context, MainActivity::class.java).apply {

--- a/app/src/main/java/app/pwhs/blockads/worker/RootProxyResumeWorker.kt
+++ b/app/src/main/java/app/pwhs/blockads/worker/RootProxyResumeWorker.kt
@@ -1,11 +1,11 @@
 package app.pwhs.blockads.worker
 
 import android.content.Context
-import android.content.Intent
-import android.os.Build
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import app.pwhs.blockads.service.RootProxyService
+import app.pwhs.blockads.data.datastore.AppPreferences
+import app.pwhs.blockads.service.ServiceController
+import kotlinx.coroutines.flow.first
 import timber.log.Timber
 
 class RootProxyResumeWorker(
@@ -19,14 +19,12 @@ class RootProxyResumeWorker(
 
     override suspend fun doWork(): Result {
         return try {
-            val intent = Intent(applicationContext, RootProxyService::class.java).apply {
-                action = RootProxyService.ACTION_START
+            val appPrefs = AppPreferences(applicationContext)
+            if (!appPrefs.protectionDesired.first()) {
+                Timber.d("Skipping Root Proxy resume; protection is no longer desired")
+                return Result.success()
             }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                applicationContext.startForegroundService(intent)
-            } else {
-                applicationContext.startService(intent)
-            }
+            ServiceController.requestStartNow(applicationContext)
             Result.success()
         } catch (e: Exception) {
             Timber.e(e, "Failed to resume Root Proxy")

--- a/app/src/main/java/app/pwhs/blockads/worker/VpnResumeWorker.kt
+++ b/app/src/main/java/app/pwhs/blockads/worker/VpnResumeWorker.kt
@@ -1,11 +1,11 @@
 package app.pwhs.blockads.worker
 
 import android.content.Context
-import android.content.Intent
-import android.os.Build
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import app.pwhs.blockads.service.AdBlockVpnService
+import app.pwhs.blockads.data.datastore.AppPreferences
+import app.pwhs.blockads.service.ServiceController
+import kotlinx.coroutines.flow.first
 import timber.log.Timber
 
 class VpnResumeWorker(
@@ -19,14 +19,12 @@ class VpnResumeWorker(
 
     override suspend fun doWork(): Result {
         return try {
-            val intent = Intent(applicationContext, AdBlockVpnService::class.java).apply {
-                action = AdBlockVpnService.ACTION_START
+            val appPrefs = AppPreferences(applicationContext)
+            if (!appPrefs.protectionDesired.first()) {
+                Timber.d("Skipping VPN resume; protection is no longer desired")
+                return Result.success()
             }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                applicationContext.startForegroundService(intent)
-            } else {
-                applicationContext.startService(intent)
-            }
+            ServiceController.requestStartNow(applicationContext)
             Result.success()
         } catch (e: Exception) {
             Timber.e(e, "Failed to resume VPN")

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -32,6 +32,9 @@
     <string name="filter_detail_last_updated">Zuletzt aktualisiert</string>
     <string name="filter_detail_update">Aktualisieren</string>
     <string name="filter_detail_delete">Löschen</string>
+    <string name="filter_detail_test_domain_title">Filterdatei prüfen</string>
+    <string name="filter_detail_domain_in_filter">Domain ist in dieser Filterdatei enthalten</string>
+    <string name="filter_detail_domain_not_in_filter">Domain ist nicht in dieser Filterdatei enthalten</string>
     <string name="logs_empty">Noch keine DNS-Anfragen protokolliert</string>
     <string name="logs_filter_all">Alle</string>
     <string name="logs_filter_blocked">Blockiert</string>
@@ -487,6 +490,8 @@
     <string name="filter_compile_channel_name">Filterkompilierung</string>
     <string name="wireguard_https_filtering_disabled">HTTPS-Filterung deaktiviert (nicht kompatibel mit WireGuard)</string>
     <string name="https_filtering_wireguard_disabled">WireGuard deaktiviert (nicht kompatibel mit HTTPS-Filterung)</string>
+    <string name="https_filtering_root_disabled">HTTPS-Filterung erfordert den lokalen VPN-Modus</string>
+    <string name="https_filtering_root_disabled_desc">Der Root-Proxy-Modus filtert nur DNS. Wechsle in den lokalen VPN-Modus, um kosmetische HTTPS-Filterung zu verwenden.</string>
     <string name="wireguard_imported">\'%1$s\' importiert</string>
     <string name="wireguard_deleted">\'%1$s\' gelöscht</string>
     <string name="wireguard_active">Aktiv: %1$s</string>
@@ -511,6 +516,17 @@
     <string name="root_proxy_start_failed_text">Root-Zugriff zum Starten des Schutzes konnte nicht erlangt werden. Tippe auf Aktivieren, um es erneut zu versuchen.</string>
     <string name="private_dns_warning_title">Privates DNS ist aktiv</string>
     <string name="private_dns_warning_text">Android Privates DNS umgeht BlockAds, daher greift die Filterung evtl. nicht. Stelle Privates DNS in den Systemeinstellungen auf Aus oder Automatisch.</string>
+    <string name="status_protection_issue">Schutzproblem</string>
+    <string name="home_protection_issue_desc">BlockAds benötigt Aufmerksamkeit, bevor der Schutz verlässlich ist</string>
+    <string name="protection_problem_title">Schutz benötigt Aufmerksamkeit</string>
+    <string name="protection_problem_both_services">Lokales VPN und Root Proxy laufen gleichzeitig. BlockAds gleicht auf den ausgewählten Modus ab.</string>
+    <string name="protection_problem_wrong_mode">Der laufende Dienst passt nicht zum ausgewählten Routing-Modus. Schalte den Schutz aus und wieder ein, um ihn abzugleichen.</string>
+    <string name="protection_problem_root_engine">Root Proxy läuft, aber die DNS-Engine antwortet nicht.</string>
+    <string name="protection_problem_root_routing">Root Proxy läuft, aber die DNS-Umleitungsregeln sind nicht aktiv.</string>
+    <string name="protection_partial_title">Teilweiser Schutz</string>
+    <string name="protection_partial_ipv6">IPv4-DNS ist geschützt, aber IPv6-DNS-Umleitung ist auf diesem Gerät nicht aktiv. Einige Anfragen können BlockAds umgehen. Deaktiviere IPv6 am Router, nutze den lokalen VPN-Modus oder prüfe als erfahrener Magisk-Nutzer ein Drittanbieter-Modul wie magisk-disable-ipv6.</string>
+    <string name="protection_partial_ipv6_magisk_link">magisk-disable-ipv6</string>
+    <string name="protection_mode_conflict">Moduskonflikt</string>
     <string name="trusted_networks_title">Vertrauenswürdige Netzwerke</string>
     <string name="trusted_networks_settings_desc">BlockAds in gewählten WLANs automatisch pausieren</string>
     <string name="trusted_networks_toggle">In vertrauenswürdigen Netzwerken pausieren</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,9 @@
     <string name="filter_detail_last_updated">Last updated</string>
     <string name="filter_detail_update">Update</string>
     <string name="filter_detail_delete">Delete</string>
+    <string name="filter_detail_test_domain_title">Check filter file</string>
+    <string name="filter_detail_domain_in_filter">Domain is contained in this filter file</string>
+    <string name="filter_detail_domain_not_in_filter">Domain is not contained in this filter file</string>
     <string name="logs_empty">No DNS queries logged yet</string>
     <string name="logs_filter_all">All</string>
     <string name="logs_filter_blocked">Blocked</string>
@@ -456,6 +459,8 @@
     <string name="wireguard_disconnect">Disconnect Tunnel</string>
     <string name="wireguard_https_filtering_disabled">HTTPS filtering disabled (incompatible with WireGuard)</string>
     <string name="https_filtering_wireguard_disabled">WireGuard disabled (incompatible with HTTPS filtering)</string>
+    <string name="https_filtering_root_disabled">HTTPS filtering requires Local VPN mode</string>
+    <string name="https_filtering_root_disabled_desc">Root Proxy mode filters DNS only. Switch to Local VPN mode to use HTTPS cosmetic filtering.</string>
     <string name="wireguard_imported">Imported \'%1$s\'</string>
     <string name="wireguard_deleted">Deleted \'%1$s\'</string>
     <string name="wireguard_active">Active: %1$s</string>
@@ -522,6 +527,17 @@
     <string name="root_proxy_start_failed_text">Could not get root access to start protection. Tap Enable to retry.</string>
     <string name="private_dns_warning_title">Private DNS is on</string>
     <string name="private_dns_warning_text">Android Private DNS bypasses BlockAds, so filtering may not apply. Set Private DNS to Off or Automatic in system settings.</string>
+    <string name="status_protection_issue">Protection issue</string>
+    <string name="home_protection_issue_desc">BlockAds needs attention before protection can be trusted</string>
+    <string name="protection_problem_title">Protection needs attention</string>
+    <string name="protection_problem_both_services">Local VPN and Root Proxy are both running. BlockAds is reconciling to the selected mode.</string>
+    <string name="protection_problem_wrong_mode">The running service does not match the selected routing mode. Turn protection off and on to reconcile it.</string>
+    <string name="protection_problem_root_engine">Root Proxy is running, but the DNS engine is not responding.</string>
+    <string name="protection_problem_root_routing">Root Proxy is running, but DNS redirection rules are not active.</string>
+    <string name="protection_partial_title">Partial protection</string>
+    <string name="protection_partial_ipv6">IPv4 DNS is protected, but IPv6 DNS interception is not active on this device. Some requests may bypass BlockAds. Disable IPv6 on your router, use Local VPN mode, or, for advanced Magisk users, consider a third-party module such as magisk-disable-ipv6.</string>
+    <string name="protection_partial_ipv6_magisk_link">magisk-disable-ipv6</string>
+    <string name="protection_mode_conflict">Mode conflict</string>
     <string name="reddit_link" translatable="false">https://www.reddit.com/r/BlockAds/</string>
     <string name="telegram_link" translatable="false">https://t.me/blockads_android</string>
     <string name="test_block_link" translatable="false">https://adblock.turtlecute.org/</string>


### PR DESCRIPTION
## Summary

This PR hardens the Root Proxy / Local VPN routing lifecycle and fixes several UI/state mismatches that could make BlockAds report protection while the wrong service, no routing rules, or an unhealthy root DNS engine was actually active.

## What changed

- Introduced a centralized protection state model so the Home UI derives the displayed mode and health from the actual running service state, not only the saved routing preference.
- Reworked service coordination so Root Proxy and Local VPN are reconciled through one controller, are mutually exclusive, and mode changes reconcile real service state even when the preference already has the target value.
- Updated resume workers, widgets, Quick Settings tile, boot handling, and settings mode changes to route starts/restarts through the controller instead of directly resurrecting stale services.
- Split the persisted “user wants protection enabled” intent from transient service lifecycle state, so Root mode can autostart correctly after boot.
- Improved Root Proxy startup and health checks: avoid fake 500 ms readiness, verify listener/routing health, keep iptables state consistent, and avoid tearing rules down on task removal while reporting RUNNING.
- Reduced destructive Root restarts for filter changes by updating tries dynamically where possible.
- Preserved and restored the user’s Private DNS settings instead of forcing a generic opportunistic mode on teardown.
- Surfaced partial IPv6 protection as a warning instead of silently treating IPv4-only interception as fully protected; the warning points advanced Magisk users to a third-party module such as magisk-disable-ipv6.
- Clarified that HTTPS filtering requires Local VPN mode, since Root standalone mode only handles DNS filtering.
- Fixed onboarding so the selected startup profile, for example Strict, is persisted instead of falling back to Standard.

## Validation

- `./gradlew :app:testDebugUnitTest :app:assembleDebug`
- Installed the generated ARM64 debug APK on a connected Android device with `adb install -r`.
