### PR TITLE
fix: clear the VPN indicator immediately on stop (#232)

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/service/AdBlockVpnService.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/AdBlockVpnService.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 
 import java.util.Locale
@@ -97,6 +98,10 @@ class AdBlockVpnService : VpnService() {
         private const val ALERT_CHANNEL_ID = "blockads_vpn_alert_channel"
         private const val NETWORK_STABILIZATION_DELAY_MS = 2000L
         private const val RESTART_CLEANUP_DELAY_MS = 1000L
+
+        // How long stopVpn() waits for the native Go engine teardown before
+        // completing the service shutdown regardless (see stopVpn, #232).
+        private const val GO_STOP_TIMEOUT_MS = 5_000L
         const val ACTION_START = "app.pwhs.blockads.START_VPN"
         const val ACTION_STOP = "app.pwhs.blockads.STOP_VPN"
         const val ACTION_PAUSE_1H = "app.pwhs.blockads.PAUSE_VPN_1H"
@@ -904,13 +909,20 @@ class AdBlockVpnService : VpnService() {
 
         // Move ALL blocking Go native calls off the main thread
         serviceScope.launch(Dispatchers.IO) {
-            // Stop Go tunnel engine (this is the heavy native call that was causing ANR)
-            goTunnelAdapter.stop()
+            // Persist "off" FIRST: everything else here can block, and a slow
+            // teardown must not leave the flag saying the VPN should be on
+            // (BootReceiver / auto-reconnect / trusted-network logic read it).
+            appPrefs.setVpnEnabled(false)
 
-            runBlocking {
-                appPrefs.setVpnEnabled(false)
-            }
-
+            // Close OUR TUN fd before the Go stop, not after (#232). The Go
+            // engine dup()s the fd, so the tun interface — and with it the
+            // system VPN key indicator — stays alive until *both* copies are
+            // closed. Go closes its dup at the top of engine.stop(), but our
+            // copy used to be closed only once that whole call returned, i.e.
+            // after resolver shutdown + gVisor stack close, which can take
+            // seconds (or block indefinitely on a long-lived flow). Closing
+            // here makes the indicator disappear as soon as Go drops its dup,
+            // regardless of how long the rest of the teardown takes.
             try {
                 vpnInterface?.close()
             } catch (e: Exception) {
@@ -918,8 +930,25 @@ class AdBlockVpnService : VpnService() {
             }
             vpnInterface = null
 
+            // Stop Go tunnel engine (this is the heavy native call that was
+            // causing ANR). Detached + time-boxed: a native stop that hangs
+            // must not keep the service stuck in STOPPING with a "Stopping…"
+            // notification forever. NonCancellable so it still finishes its
+            // cleanup after stopSelf() cancels serviceScope.
+            val goStop = serviceScope.launch(NonCancellable) { goTunnelAdapter.stop() }
+            if (withTimeoutOrNull(GO_STOP_TIMEOUT_MS) { goStop.join() } == null) {
+                Timber.w("Go tunnel stop still running after ${GO_STOP_TIMEOUT_MS}ms — finishing shutdown anyway")
+            }
+
             // Switch back to main thread for UI/Service lifecycle operations
             withContext(Dispatchers.Main) {
+                // A start/restart may have taken over while we were waiting on
+                // the native stop (the timeout above lets us get here even when
+                // it hangs). Never tear down a session that is no longer ours.
+                if (_state.value != VpnState.STOPPING) {
+                    Timber.w("Shutdown superseded by ${_state.value} — leaving the new session alone")
+                    return@withContext
+                }
                 _state.value = VpnState.STOPPED
                 lastStoppedTimestamp = System.currentTimeMillis()
                 _privateDnsStrict.value = false


### PR DESCRIPTION
## Problem

Toggling BlockAds off (QS tile or elsewhere) leaves the system VPN key indicator in the status bar for anywhere from ~3s to indefinitely, while the app itself already shows "off". Reported on a Galaxy S23 / One UI 7 (Android 15), BlockAds 6.5.2.

## Root cause — teardown ordering, not the tile

The Go engine `dup()`s the TUN fd it is handed (`tunnel/fulltunnel.go:158`, `tunnel/engine.go:425`), so the tun interface — and with it the status-bar VPN indicator — stays alive until **both** fd copies are closed.

Go closes its dup early, at the top of `Engine.Stop()` (`tunnel/engine.go:531`). Our `ParcelFileDescriptor`, however, was closed only *after* the whole `goTunnelAdapter.stop()` call returned — i.e. after `resolver.Shutdown()`, `pipe.Close()` and `stack.Stop()` → gVisor `stack.Close()` (`tunnel/engine.go:586-612`). That tail takes seconds under load and can block for as long as a relayed flow stays open.

At the same time `stopVpn()` has already set the state to `STOPPING`, and `HomeViewModel.vpnEnabled` is `state == RUNNING`, so the UI reads "off" immediately. That is exactly the reported mismatch: app says off, icon lingers. It also explains why changing connectivity, or an app-side on/off cycle, clears it.

## Changes (`AdBlockVpnService.stopVpn()`)

- **Close our TUN fd before the Go stop, not after.** The interface now drops as soon as Go releases its dup, independent of how long the rest of the native teardown takes. This also removes a latent race in the old order, where a stale `stopVpn` could close a PFD a restart had just established.
- **Persist `setVpnEnabled(false)` first.** A hung teardown used to leave the flag saying the VPN should be on — BootReceiver, auto-reconnect and the trusted-network logic all read it. (Also drops a pointless `runBlocking` inside a coroutine.)
- **Time-box the native stop** (5s, detached `NonCancellable` so it still completes its own cleanup) so the service can't sit in `STOPPING` behind a "Stopping…" notification forever.
- **Guard the lifecycle teardown on the state still being `STOPPING`**, so a start/restart that took over during that window isn't killed by the stale shutdown's `stopSelf()`.

Kotlin only — no Go changes, so the checked-in `tunnel.aar` is untouched.

## Validation

`./gradlew assembleDebug` passes. The defect is confirmed by reading the ordering; the symptom itself was not reproduced locally (no Galaxy S23 / One UI 7 on hand, and Samsung has its own icon-refresh lag), so reporter confirmation on a build from this branch is welcome.

## Not in this PR

`AdBlockTileService.onClick()` reads `AdBlockVpnService.isRunning` synchronously right after an async start/stop and derives the tile label from it — correct only by accident, and unrelated to the status-bar indicator. Worth a separate change.


Fixes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN shutdown reliability by preventing the app from remaining stuck in a stopping state.
  * Added a timeout for tunnel shutdown so the service can recover if the native tunnel does not stop promptly.
  * Prevented an older shutdown process from disrupting a newly started VPN session.
  * VPN settings are now updated earlier during shutdown for more consistent state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->