### PR TITLE
docs: fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,4 +164,4 @@ Open an issue or submit a PR with your translations.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=pass-with-high-score/blockads-android&type=Date)](https://www.star-history.com/#pass-with-high-score/blockads-android&Date)
+[![Star History Chart](https://afterglow.watch/svg?repos=pass-with-high-score/blockads-android&type=Date)](https://afterglow.watch)


### PR DESCRIPTION
The star history chart at the bottom of the README has been a broken image since GitHub removed the stargazer endpoints at the end of June; api.star-history.com doesn't render the /svg URLs anymore.

There are two real fixes and this PR is only one of them. You can keep star-history: they now bring the old chart back if you fetch a sealed_token URL from their site, which keeps your full pre-June history. Or take this PR, which points the chart at afterglow.watch instead. Same URL shape, daily snapshots, free, no token, but the measured line only starts August 1, when tracking began.

Worth saying why I picked this one: blockads is gaining about 39 stars a day right now, which is fast. The public board on the site only lists repos above 2,000 stars by default, but any repo carrying the chart or badge is listed regardless of size, so this would put you on it.

Disclosure: I run afterglow.watch, that's why I'm proposing my own chart as the fix. Deleting the dead embed is a perfectly good third option. Happy to close this whichever way you go.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart image and link to use Afterglow Watch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->