### PR TITLE
fix: star history chart is broken, switch to working mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,4 +164,4 @@ Open an issue or submit a PR with your translations.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=pass-with-high-score/blockads-android&type=Date)](https://www.star-history.com/#pass-with-high-score/blockads-android&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=pass-with-high-score/blockads-android&type=Date)](https://star-history.dera.page/#pass-with-high-score/blockads-android&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because the upstream service is limited by GitHub's stargazer API restrictions, so the image no longer loads. This PR points the chart at a working alternative (star-history.dera.page) that uses a different data source and needs no API token. The wrapping link and the chart image are both updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart link and image to use the new hosting domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->