### PR TITLE
feat(vpn): add a WireGuard toggle to let apps bypass the tunnel

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/data/datastore/AppPreferences.kt
+++ b/app/src/main/java/app/pwhs/blockads/data/datastore/AppPreferences.kt
@@ -141,6 +141,7 @@ class AppPreferences(context: Context) {
     val wgProfiles: Flow<List<WireGuardProfile>> get() = wireguard.wgProfiles
     val wgActiveProfileId: Flow<String?> get() = wireguard.wgActiveProfileId
     val excludeLan: Flow<Boolean> get() = wireguard.excludeLan
+    val allowAppBypass: Flow<Boolean> get() = wireguard.allowAppBypass
 
     // ── Mutator & Snapshot Delegates ─────────────────────────────────────
     suspend fun setVpnEnabled(enabled: Boolean) = vpnSecurity.setVpnEnabled(enabled)
@@ -208,4 +209,5 @@ class AppPreferences(context: Context) {
     suspend fun clearAllWgProfiles() = wireguard.clearAllWgProfiles()
     suspend fun migrateLegacyWgConfigIfNeeded() = wireguard.migrateLegacyWgConfigIfNeeded()
     suspend fun setExcludeLan(enabled: Boolean) = wireguard.setExcludeLan(enabled)
+    suspend fun setAllowAppBypass(enabled: Boolean) = wireguard.setAllowAppBypass(enabled)
 }

--- a/app/src/main/java/app/pwhs/blockads/data/datastore/prefs/WireGuardPreferences.kt
+++ b/app/src/main/java/app/pwhs/blockads/data/datastore/prefs/WireGuardPreferences.kt
@@ -20,6 +20,7 @@ class WireGuardPreferences(private val dataStore: DataStore<Preferences>) {
         val KEY_WG_PROFILES_JSON = stringPreferencesKey("wg_profiles_json")
         val KEY_WG_ACTIVE_PROFILE_ID = stringPreferencesKey("wg_active_profile_id")
         val KEY_EXCLUDE_LAN = booleanPreferencesKey("exclude_lan")
+        val KEY_ALLOW_APP_BYPASS = booleanPreferencesKey("allow_app_bypass")
 
         const val ROUTING_MODE_DIRECT = "direct"
         const val ROUTING_MODE_WIREGUARD = "wireguard"
@@ -42,6 +43,10 @@ class WireGuardPreferences(private val dataStore: DataStore<Preferences>) {
 
     val excludeLan: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[KEY_EXCLUDE_LAN] ?: false
+    }
+
+    val allowAppBypass: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[KEY_ALLOW_APP_BYPASS] ?: false
     }
 
     private fun readProfilesFromPrefs(prefs: Preferences): List<WireGuardProfile> {
@@ -164,6 +169,12 @@ class WireGuardPreferences(private val dataStore: DataStore<Preferences>) {
     suspend fun setExcludeLan(enabled: Boolean) {
         dataStore.edit { prefs ->
             prefs[KEY_EXCLUDE_LAN] = enabled
+        }
+    }
+
+    suspend fun setAllowAppBypass(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_ALLOW_APP_BYPASS] = enabled
         }
     }
 }

--- a/app/src/main/java/app/pwhs/blockads/service/vpn/VpnTunnelBuilder.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/vpn/VpnTunnelBuilder.kt
@@ -123,7 +123,10 @@ class VpnTunnelBuilder(
                 }
             }
 
-            if (wgConfig == null) {
+            // A non-bypassable tunnel refuses an app's explicit bind to an
+            // underlying network, which is what breaks wireless Android Auto.
+            val allowAppBypass = runBlocking { appPrefs.allowAppBypass.first() }
+            if (wgConfig == null || allowAppBypass) {
                 builder.allowBypass()
             }
 

--- a/app/src/main/java/app/pwhs/blockads/ui/wireguard/WireGuardImportScreen.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/wireguard/WireGuardImportScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.AltRoute
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Dns
 import androidx.compose.material.icons.filled.FileOpen
@@ -62,6 +63,7 @@ import app.pwhs.blockads.R
 import app.pwhs.blockads.data.entities.WireGuardProfile
 import app.pwhs.blockads.ui.wireguard.component.EmptyState
 import app.pwhs.blockads.ui.wireguard.component.ProfileRow
+import app.pwhs.blockads.ui.wireguard.component.SettingToggleCard
 import org.koin.androidx.compose.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -79,6 +81,7 @@ fun WireGuardImportScreen(
     val isWgActive by viewModel.isWgActive.collectAsStateWithLifecycle()
     val splitDnsZones by viewModel.splitDnsZones.collectAsStateWithLifecycle()
     val excludeLan by viewModel.excludeLan.collectAsStateWithLifecycle()
+    val allowAppBypass by viewModel.allowAppBypass.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember { SnackbarHostState() }
     val resources = LocalResources.current
@@ -201,9 +204,22 @@ fun WireGuardImportScreen(
                     }
 
                     item {
-                        ExcludeLanCard(
+                        SettingToggleCard(
+                            icon = Icons.Filled.Lan,
+                            title = stringResource(R.string.exclude_lan_title),
+                            description = stringResource(R.string.exclude_lan_description),
                             checked = excludeLan,
                             onCheckedChange = { viewModel.setExcludeLan(it) },
+                        )
+                    }
+
+                    item {
+                        SettingToggleCard(
+                            icon = Icons.AutoMirrored.Filled.AltRoute,
+                            title = stringResource(R.string.allow_app_bypass_title),
+                            description = stringResource(R.string.allow_app_bypass_description),
+                            checked = allowAppBypass,
+                            onCheckedChange = { viewModel.setAllowAppBypass(it) },
                         )
                     }
 
@@ -353,59 +369,6 @@ private fun SplitDnsCard(
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
                 shape = RoundedCornerShape(12.dp),
-            )
-        }
-    }
-}
-
-@Composable
-private fun ExcludeLanCard(
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
-) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.weight(1f),
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Lan,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(20.dp),
-                )
-                Spacer(Modifier.width(8.dp))
-                Column {
-                    Text(
-                        text = stringResource(R.string.exclude_lan_title),
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                    Text(
-                        text = stringResource(R.string.exclude_lan_description),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-            Switch(
-                checked = checked,
-                onCheckedChange = onCheckedChange,
-                colors = SwitchDefaults.colors(
-                    checkedThumbColor = MaterialTheme.colorScheme.primary,
-                    checkedTrackColor = MaterialTheme.colorScheme.primaryContainer,
-                ),
             )
         }
     }

--- a/app/src/main/java/app/pwhs/blockads/ui/wireguard/WireGuardImportViewModel.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/wireguard/WireGuardImportViewModel.kt
@@ -59,6 +59,10 @@ class WireGuardImportViewModel(
     private val _excludeLan = MutableStateFlow(false)
     val excludeLan: StateFlow<Boolean> = _excludeLan.asStateFlow()
 
+    /** Let apps that bind a socket to a specific network skip the tunnel. */
+    private val _allowAppBypass = MutableStateFlow(false)
+    val allowAppBypass: StateFlow<Boolean> = _allowAppBypass.asStateFlow()
+
     /** One-shot UI events. */
     private val _events = MutableSharedFlow<WireGuardUiEvent>()
     val events: SharedFlow<WireGuardUiEvent> = _events.asSharedFlow()
@@ -77,6 +81,7 @@ class WireGuardImportViewModel(
                 appPrefs.getRoutingModeSnapshot() == AppPreferences.ROUTING_MODE_WIREGUARD
             _splitDnsZones.value = appPrefs.splitDnsZones.first()
             _excludeLan.value = appPrefs.excludeLan.first()
+            _allowAppBypass.value = appPrefs.allowAppBypass.first()
         }
     }
 
@@ -201,6 +206,14 @@ class WireGuardImportViewModel(
     fun setExcludeLan(enabled: Boolean) {
         _excludeLan.value = enabled
         viewModelScope.launch { appPrefs.setExcludeLan(enabled) }
+    }
+
+    fun setAllowAppBypass(enabled: Boolean) {
+        _allowAppBypass.value = enabled
+        viewModelScope.launch {
+            appPrefs.setAllowAppBypass(enabled)
+            ServiceController.requestRestart(getApplication())
+        }
     }
 
     fun setSplitDnsZones(zones: String) {

--- a/app/src/main/java/app/pwhs/blockads/ui/wireguard/component/SettingToggleCard.kt
+++ b/app/src/main/java/app/pwhs/blockads/ui/wireguard/component/SettingToggleCard.kt
@@ -1,0 +1,81 @@
+package app.pwhs.blockads.ui.wireguard.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SettingToggleCard(
+    icon: ImageVector,
+    title: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.weight(1f),
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Column {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = MaterialTheme.colorScheme.primary,
+                    checkedTrackColor = MaterialTheme.colorScheme.primaryContainer,
+                ),
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -226,6 +226,8 @@
     <string name="split_dns_description">Comma-separated domain zones to resolve via WireGuard DNS instead of upstream (e.g., internal,local,lan)</string>
     <string name="exclude_lan_title">Exclude LAN Traffic</string>
     <string name="exclude_lan_description">Allow access to local network devices (printers, NAS, local servers) while WireGuard is active</string>
+    <string name="allow_app_bypass_title">Allow Apps to Bypass VPN</string>
+    <string name="allow_app_bypass_description">Let apps that pin a connection to one network (wireless Android Auto, casting, device setup) reach it directly. Everything else still goes through the tunnel.</string>
     <string name="settings_hide_from_recents_title">Hide from Recent Apps</string>
     <string name="settings_hide_from_recents_subtitle">Hide BlockAds from the recent apps screen</string>
 </resources>

--- a/app/src/test/java/app/pwhs/blockads/data/datastore/prefs/WireGuardPreferencesTest.kt
+++ b/app/src/test/java/app/pwhs/blockads/data/datastore/prefs/WireGuardPreferencesTest.kt
@@ -1,0 +1,39 @@
+package app.pwhs.blockads.data.datastore.prefs
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class WireGuardPreferencesTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private fun newPreferences(): WireGuardPreferences {
+        val file = File(tempFolder.newFolder(), "wireguard.preferences_pb")
+        return WireGuardPreferences(PreferenceDataStoreFactory.create { file })
+    }
+
+    @Test
+    fun `allowAppBypass stays opt-in so WireGuard mode starts non-bypassable`() = runTest {
+        assertFalse(newPreferences().allowAppBypass.first())
+    }
+
+    @Test
+    fun `allowAppBypass keeps an explicit opt-in`() = runTest {
+        val prefs = newPreferences()
+        prefs.setAllowAppBypass(true)
+        assertTrue(prefs.allowAppBypass.first())
+    }
+
+    @Test
+    fun `excludeLan stays opt-in`() = runTest {
+        assertFalse(newPreferences().excludeLan.first())
+    }
+}


### PR DESCRIPTION
WireGuard mode skipped allowBypass(), making the VPN non-bypassable. An app that pins a socket to a specific underlying network — wireless Android Auto pinning to the head unit's link — then has that bind refused outright, whatever the route table holds. Direct mode has always called allowBypass(), so this only brings WireGuard mode within reach of the same behavior; it stays off by default, since turning it on lets any app skip DNS interception and filtering for sockets it binds itself.

Verified on a Pixel 10 Pro against a split-tunnel config (AllowedIPs 10.13.13.0/24, 192.168.1.2/32, no IPv6 route, LAN exclusion off): wireless Android Auto fails with the toggle off and connects with it on, with routing identical in both runs.

The excludeLan card moves to a shared SettingToggleCard so both toggles use the same component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “Allow Apps to Bypass VPN” setting for WireGuard connections.
  - Users can enable app-level bypass for apps that require direct access to a specific network.
  - Added a shared toggle-card design for WireGuard settings.
  - VPN services restart automatically when the bypass setting changes.

- **Bug Fixes**
  - Apps remain routed through the VPN by default unless bypass is explicitly enabled.

- **Tests**
  - Added coverage for default and enabled app-bypass preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->