### PR TITLE
fix(vpn): reset the userspace TCP stack flag on every VPN start

### DIFF
--- a/app/src/main/java/app/pwhs/blockads/service/GoTunnelAdapter.kt
+++ b/app/src/main/java/app/pwhs/blockads/service/GoTunnelAdapter.kt
@@ -305,7 +305,18 @@ class GoTunnelAdapter(
         // source-UID visibility, so per-app scoping (MITM only the
         // selected browsers) actually works on Android 10+. The legacy
         // VpnService HTTP proxy path is no longer used.
-        if (httpsFilteringEnabled && certDir.isNotEmpty()) {
+        // WireGuard and the userspace TCP/IP stack are mutually exclusive:
+        // the stack terminates each flow and dials it directly, bypassing the
+        // WG tunnel. The engine is created once (onCreate) and reused across
+        // VPN restarts, so a `useTcpStack=true` left over from an earlier
+        // HTTPS-filtering session would silently hijack all non-DNS WireGuard
+        // traffic — the handshake still completes, but SSH/ping never enter
+        // the tunnel. Set the flag explicitly on every start from the current
+        // mode so stale state can't leak across a mode switch.
+        val mitmMode = httpsFilteringEnabled && certDir.isNotEmpty() && wgConfigJson.isEmpty()
+        engine.setUseTcpStack(mitmMode)
+
+        if (mitmMode) {
             try {
                 val pm = context.packageManager
                 val uids = selectedBrowsers.mapNotNull { pkg ->
@@ -316,8 +327,7 @@ class GoTunnelAdapter(
                     }
                 }.joinToString(",")
 
-                // Enable the stack, init CA + filter, register UIDs.
-                engine.setUseTcpStack(true)
+                // Init CA + filter, register UIDs.
                 engine.startStackMitm(certDir)
                 engine.setMitmAllowedUIDs(uids)
                 engine.setFilterHttp3(filterHttp3)
@@ -374,7 +384,7 @@ class GoTunnelAdapter(
             Timber.d("Starting Go tunnel engine in WIREGUARD mode (fd=$fd)")
             engine.start(fd.toLong(), protector, wgConfigJson)
         } else {
-            Timber.d("Starting Go tunnel engine in FULL-TUNNEL mode (fd=$fd, mitm=${httpsFilteringEnabled && certDir.isNotEmpty()})")
+            Timber.d("Starting Go tunnel engine in FULL-TUNNEL mode (fd=$fd, mitm=$mitmMode)")
             engine.startFull(fd.toLong(), protector)
         }
     }


### PR DESCRIPTION
In WireGuard mode the tunnel comes up and the handshake completes, but no traffic actually goes through it — SSH, ping and general browsing all fail, while DNS keeps working.

The Go engine is created once in onCreate and reused across VPN restarts, and setUseTcpStack(true) was only ever set (for HTTPS filtering), never cleared. Any session that had HTTPS filtering enabled leaves the flag true, so on the next start the DNS interceptor diverts every non-DNS packet to the userspace TCP/IP stack, which terminates each flow and dials it directly — bypassing WireGuard entirely.

WireGuard and the stack are mutually exclusive, so derive the flag from the current mode on every start instead of letting it persist across a mode switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected tunnel mode selection when HTTPS filtering and WireGuard configurations are used together.
  - HTTPS filtering now activates only when the required certificate configuration is available and no WireGuard configuration is active.
  - Improved tunnel startup consistency by applying the appropriate networking mode on every start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->